### PR TITLE
Update Invincible and The Boys episode ratings datasets

### DIFF
--- a/data/invincible_ep_ratings.csv
+++ b/data/invincible_ep_ratings.csv
@@ -23,5 +23,3 @@ season,episode,title,rating,votes
 3,6,All I Can Say Is I'm Sorry,8.7,16624
 3,7,What Have I Done?,9.7,37003
 3,8,I Thought You'd Never Shut Up,9.8,80717
-4,1,Episode #4.1,NA,0
-5,1,Episode #5.1,NA,0

--- a/data/the_boys_ep_ratings.csv
+++ b/data/the_boys_ep_ratings.csv
@@ -1,0 +1,33 @@
+season,episode,title,rating,votes
+1,1,The Name of the Game,8.7,24694
+1,2,Cherry,8.5,20763
+1,3,Get Some,8.3,19463
+1,4,The Female of the Species,8.7,19631
+1,5,Good for the Soul,8.3,18828
+1,6,The Innocents,8.1,17852
+1,7,The Self-Preservation Society,8.7,18328
+1,8,You Found Me,9.1,21760
+2,1,The Big Ride,8.1,17860
+2,2,Proper Preparation and Planning,7.7,17122
+2,3,Over the Hill with the Swords of a Thousand Men,9,19785
+2,4,Nothing Like It in the World,8,16572
+2,5,We Gotta Go Now,8.3,16621
+2,6,The Bloody Doors Off,8.9,18358
+2,7,"Butcher, Baker, Candlestick Maker",9,18929
+2,8,What I Know,9.4,26220
+3,1,Payback,8.3,18727
+3,2,The Only Man in the Sky,8.6,18553
+3,3,Barbary Coast,8.2,17289
+3,4,Glorious Five Year Plan,8.9,19456
+3,5,The Last Time to Look on This World of Lies,8.3,17312
+3,6,Herogasm,9.6,43389
+3,7,Here Comes a Candle to Light You to Bed,8.9,19974
+3,8,The Instant White-Hot Wild,8.3,23945
+4,1,Department of Dirty Tricks,7.4,23192
+4,2,Life Among the Septics,7.1,20794
+4,3,We'll Keep the Red Flag Flying Here,7.5,19707
+4,4,Wisdom of the Ages,8.9,27982
+4,5,"Beware the Jabberwock, My Son",8.1,20058
+4,6,Dirty Business,7.5,20191
+4,7,The Insider,8.2,17874
+4,8,Season Four Finale,9.1,31134


### PR DESCRIPTION
### Motivation
- Ensure the episode rating datasets reflect only released episodes with valid ratings and votes so downstream analysis/plots are accurate.
- Provide a matching episode-ratings CSV for "The Boys" so both series are available in the same schema for plotting and analysis.

### Description
- Trimmed placeholder rows (entries with `rating` == `NA` or `votes` == `0`) from `data/invincible_ep_ratings.csv` so it contains only released episodes with ratings and votes.
- Added `data/the_boys_ep_ratings.csv` by extracting released-episode rows for `imdb_id == tt1190634` from `data/top250_imdb_series.csv` and writing them in the `season,episode,title,rating,votes` schema.
- Ensured both files follow the same schema expected by the plotting pipeline (`season,episode,title,rating,votes`).

### Testing
- Ran `rg -n "invincible|the boys|boys" .` to locate relevant references and confirm files are referenced (succeeded).
- Executed Python scripts to remove `NA`/`0` placeholder rows and to generate `data/the_boys_ep_ratings.csv` from `data/top250_imdb_series.csv` (succeeded).
- Inspected the resulting CSVs with `sed -n '1,120p' data/invincible_ep_ratings.csv` and `nl -ba` on both files to verify contents and row counts (succeeded).
- Created PR metadata via `make_pr` with a summary and details describing the dataset updates (succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a120ff06b748326a2f97a6f97adb9c6)