### PR TITLE
Add Invincible season 4 to IMDb rating plot

### DIFF
--- a/data/invincible_ep_ratings.csv
+++ b/data/invincible_ep_ratings.csv
@@ -23,5 +23,11 @@ season,episode,title,rating,votes
 3,6,All I Can Say Is I'm Sorry,8.7,16624
 3,7,What Have I Done?,9.7,37003
 3,8,I Thought You'd Never Shut Up,9.8,80717
-4,1,Episode #4.1,NA,0
-5,1,Episode #5.1,NA,0
+4,1,Making the World a Better Place,8.3,15879
+4,2,I'll Give You the Grand Tour,9.3,19294
+4,3,I Gotta Get Some Air,8.1,14598
+4,4,Hurm,6.6,23577
+4,5,Give Us a Moment,9.8,42203
+4,6,You Look Horrible,9.1,25209
+4,7,Don't Do Anything Rash,9.9,46672
+4,8,Don't Leave Me Hanging Here,8.9,25227

--- a/web_scraping/imdb_season_episode_ratings_plot.R
+++ b/web_scraping/imdb_season_episode_ratings_plot.R
@@ -27,7 +27,20 @@ get_imdb_season_episodes <- function(imdb_input, season) {
     season
   )
 
-  page <- rvest::read_html(url)
+  html <- httr::GET(
+    url,
+    httr::add_headers(
+      `User-Agent` = paste(
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64)",
+        "AppleWebKit/537.36 (KHTML, like Gecko)",
+        "Chrome/120.0.0.0 Safari/537.36"
+      ),
+      `Accept-Language` = "en-US,en;q=0.9"
+    )
+  ) |>
+    httr::content(as = "text", encoding = "UTF-8")
+
+  page <- rvest::read_html(html)
 
   next_data_txt <- page %>%
     rvest::html_element("script#__NEXT_DATA__") %>%


### PR DESCRIPTION
## Summary
- Add all eight Invincible season 4 episodes with IMDb ratings and vote counts to `data/invincible_ep_ratings.csv`
- Remove unreleased season 4/5 placeholder rows
- Send a browser User-Agent in the IMDB episode scraper to reduce bot-blocking on future runs

## Test plan
- [ ] Knit `imdb_rating_plot.Rmd` and confirm the Invincible heatmap shows season 4
- [ ] Re-run `web_scraping/imdb_season_episode_ratings_plot.R` locally to refresh ratings when IMDb allows