### PR TITLE
[codex] Add Best Picture winners update check

### DIFF
--- a/.github/workflows/update_best_picture_winners.yml
+++ b/.github/workflows/update_best_picture_winners.yml
@@ -1,0 +1,43 @@
+name: Check Best Picture winners
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "23 16 23 3 *" # March 23 each year, 16:23 UTC (~9:23am Pacific daylight time)
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          dependencies: '"all"'
+
+      - name: Refresh Best Picture winners
+        run: Rscript scripts/check_best_picture_winners.R
+
+      - name: Open PR if data changed
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: auto/update-best-picture-winners
+          delete-branch: true
+          commit-message: "Update Best Picture winners"
+          title: "Update Best Picture winners"
+          body: |
+            This scheduled check refreshed the Best Picture winners dataset.
+
+            Review the CSV diff and any Best Picture page copy that may need a human update before merging.
+          add-paths: |
+            data/best_picture_winners.csv
+            data/best_picture_box_office_cache.rds

--- a/scripts/check_best_picture_winners.R
+++ b/scripts/check_best_picture_winners.R
@@ -1,0 +1,52 @@
+`%>%` <- magrittr::`%>%`
+
+csv_path <- here::here("data", "best_picture_winners.csv")
+cache_path <- here::here("data", "best_picture_box_office_cache.rds")
+
+old_winners <- if (file.exists(csv_path)) {
+  readr::read_csv(csv_path, show_col_types = FALSE)
+} else {
+  tibble::tibble()
+}
+
+refresh_box_office <- TRUE
+box_office_cache_path <- cache_path
+
+message("Refreshing Best Picture winners from IMDb...")
+source(here::here("web_scraping", "best_picture_winners.R"))
+
+new_winners <- oscar_winners_clean
+readr::write_csv(new_winners, csv_path)
+
+old_latest <- old_winners %>%
+  dplyr::arrange(dplyr::desc(oscar_year)) %>%
+  dplyr::slice_head(n = 5) %>%
+  dplyr::select(oscar_year, oscar_titles, movie_year, oscar_imdb_ratings)
+
+new_latest <- new_winners %>%
+  dplyr::arrange(dplyr::desc(oscar_year)) %>%
+  dplyr::slice_head(n = 5) %>%
+  dplyr::select(oscar_year, oscar_titles, movie_year, oscar_imdb_ratings)
+
+summary_lines <- c(
+  "## Best Picture Winners Check",
+  "",
+  sprintf("Generated at: %s", format(Sys.time(), "%Y-%m-%d %H:%M:%S %Z")),
+  "",
+  "### Latest checked-in rows",
+  "",
+  paste(capture.output(print(old_latest, n = Inf)), collapse = "\n"),
+  "",
+  "### Latest refreshed rows",
+  "",
+  paste(capture.output(print(new_latest, n = Inf)), collapse = "\n")
+)
+
+summary_path <- Sys.getenv("GITHUB_STEP_SUMMARY")
+if (nzchar(summary_path)) {
+  cat(paste(summary_lines, collapse = "\n"), "\n", file = summary_path, append = TRUE)
+} else {
+  cat(paste(summary_lines, collapse = "\n"), "\n")
+}
+
+message("Wrote refreshed winners to ", csv_path)


### PR DESCRIPTION
## Summary

Adds a semi-automatic Best Picture winners update flow.

- Adds an R script that refreshes the Best Picture winners CSV using the existing IMDb scraper and writes a before/after summary.
- Adds a yearly/manual GitHub Actions workflow that opens a PR when the refreshed data changes.

## Impact

This keeps the Oscar data from going stale while still requiring review before publishing any site changes.

## Validation

- `Rscript -e 'parse("scripts/check_best_picture_winners.R"); cat("R parse OK\n")'`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/update_best_picture_winners.yml"); puts "YAML parse OK"'`

I did not run the live IMDb refresh locally, so this PR does not rewrite the current data.