### PR TITLE
Auto-update firefighter schedule page

### DIFF
--- a/.github/workflows/pages-rmarkdown.yml
+++ b/.github/workflows/pages-rmarkdown.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     branches: ["main"]
   workflow_dispatch:
+  schedule:
+    - cron: "11 12 * * *" # Daily 12:11 UTC (~5:11am Pacific daylight time)
 
 permissions:
   contents: read
@@ -108,7 +110,7 @@ jobs:
 
 
       - name: Upload Pages artifact
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        if: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/main' }}
         uses: actions/upload-pages-artifact@v3
         with:
           path: _site
@@ -138,4 +140,3 @@ jobs:
           message: "🚀 Preview: ${{ steps.deployment.outputs.page_url }}"
           mode: upsert
           create_if_not_exists: true
-


### PR DESCRIPTION
## Summary

Schedules the existing GitHub Pages workflow to rebuild/deploy daily so the firefighter schedule page stays current.

## Why

The firefighter page filters schedules from `Sys.Date()`, so the rendered GitHub Pages output can become stale between commits. A scheduled Pages run refreshes the generated HTML automatically.

## Changes

- Added a daily cron trigger to the Pages workflow.
- Allowed scheduled non-PR workflow runs to upload the Pages artifact for deployment.

## Validation

- `Rscript -e 'if (requireNamespace("yaml", quietly=TRUE)) { yaml::read_yaml(".github/workflows/pages-rmarkdown.yml"); cat("workflow yaml parsed\n") } else { cat("yaml package unavailable; skipped parse\n") }'`