### PR TITLE
Serialize gh-pages deploy jobs to prevent push races

### DIFF
--- a/.github/workflows/pages-branch-previews.yml
+++ b/.github/workflows/pages-branch-previews.yml
@@ -114,6 +114,11 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    # Serialize all jobs that push to gh-pages so concurrent runs (PR previews,
+    # main pushes, preview cleanups) don't race on `git push origin gh-pages`.
+    concurrency:
+      group: gh-pages-deploy
+      cancel-in-progress: false
     steps:
       - uses: actions/download-artifact@v4
         with:
@@ -138,6 +143,9 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+    concurrency:
+      group: gh-pages-deploy
+      cancel-in-progress: false
     steps:
       - uses: actions/download-artifact@v4
         with:
@@ -166,6 +174,9 @@ jobs:
     name: Remove PR preview on close
     if: ${{ github.event_name == 'pull_request' && github.event.action == 'closed' }}
     runs-on: ubuntu-latest
+    concurrency:
+      group: gh-pages-deploy
+      cancel-in-progress: false
     steps:
       - name: Checkout gh-pages
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

- Add a shared `gh-pages-deploy` concurrency group on every job that pushes to `gh-pages` (`deploy_prod`, `deploy_preview`, `cleanup_preview`) with `cancel-in-progress: false` so concurrent deploys queue instead of racing.

## Why

The prod-deploy job on the `main` push for [3a68fe2](https://github.com/cavandonohoe/cavandonohoe.github.io/commit/3a68fe2afd213765d2369d360bcd80f6cc45ca99) failed with:

```
[command]/usr/bin/git push origin gh-pages
 ! [rejected]        gh-pages -> gh-pages (fetch first)
```

A PR-preview deploy from another branch updated `gh-pages` while `peaceiris/actions-gh-pages@v3` was building its commit on the `main` runner. The action does not fetch/retry on a non-fast-forward, so the second push fails outright.

The existing top-level `concurrency:` block is keyed per-ref/per-event (`${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}`), which correctly serializes builds for the same source. But it does **not** serialize across different sources (main push vs. PR preview vs. PR-close cleanup), which is exactly where the race lives. A separate job-level group keyed only on `gh-pages-deploy` covers that gap.

`cancel-in-progress: false` is intentional — we never want to interrupt an in-flight deploy mid-push.

## Test plan

- [ ] PR preview build/deploy succeeds on this PR (proves `deploy_preview` still works under the new concurrency group)
- [ ] After merge, the `main` push deploy succeeds without a `(fetch first)` rejection
- [ ] Open + close a throwaway PR to confirm `cleanup_preview` still serializes correctly with any concurrent deploy