### PR TITLE
Add retry logic to IMDb-based data refresh wrappers

### DIFF
--- a/scripts/refresh_top1000_box_office.R
+++ b/scripts/refresh_top1000_box_office.R
@@ -5,7 +5,7 @@
 # scrapers and writes the resulting CSVs, skipping the Gmail notify step
 # that requires user-level OAuth.
 #
-# IMDb intermittently returns empty / unparseable bodies to GitHub Actions
+# IMDb intermittently returns empty / unparsable bodies to GitHub Actions
 # IPs, so each underlying scrape is retried up to a few times with backoff
 # before we give up.
 #

--- a/scripts/refresh_top1000_box_office.R
+++ b/scripts/refresh_top1000_box_office.R
@@ -5,10 +5,13 @@
 # scrapers and writes the resulting CSVs, skipping the Gmail notify step
 # that requires user-level OAuth.
 #
+# IMDb intermittently returns empty / unparseable bodies to GitHub Actions
+# IPs, so each underlying scrape is retried up to a few times with backoff
+# before we give up.
+#
 # Usage:
 #   Rscript scripts/refresh_top1000_box_office.R
 
-# Defang the email step before any sourcing happens.
 send_gmail_notification <- function(...) {
   message("[CI] Skipping Gmail notification.")
   invisible(NULL)
@@ -23,13 +26,47 @@ source <- function(file, ...) {
   orig_source(file, ...)
 }
 
-# Match the variables expected by the scrapers.
 sleep_after <- FALSE
 refresh_box_office <- TRUE
 refresh_ratings <- FALSE
 
+run_with_retry <- function(label, expr, max_attempts = 3) {
+  expr <- substitute(expr)
+  envir <- parent.frame()
+  for (attempt in seq_len(max_attempts)) {
+    res <- tryCatch(eval(expr, envir = envir), error = function(e) e)
+    if (!inherits(res, "error")) {
+      return(invisible(res))
+    }
+    msg <- conditionMessage(res)
+    message(sprintf(
+      "[CI] %s attempt %d/%d failed: %s",
+      label, attempt, max_attempts, msg
+    ))
+    cache_dir <- here::here("web_scraping", "cache")
+    if (dir.exists(cache_dir)) {
+      message("[CI] Clearing scraper cache at ", cache_dir)
+      unlink(cache_dir, recursive = TRUE, force = TRUE)
+    }
+    if (attempt < max_attempts) {
+      Sys.sleep(2 ^ attempt * 5)
+    } else {
+      stop(sprintf(
+        "%s failed after %d attempts: %s",
+        label, max_attempts, msg
+      ))
+    }
+  }
+}
+
 message("[CI] Starting Best Picture scrape...")
-orig_source(here::here("web_scraping", "best_picture_winners.R"), local = FALSE)
+run_with_retry(
+  "Best Picture scrape",
+  orig_source(
+    here::here("web_scraping", "best_picture_winners.R"),
+    local = FALSE
+  )
+)
 readr::write_csv(
   oscar_winners_clean,
   here::here("data", "best_picture_winners.csv")
@@ -37,7 +74,13 @@ readr::write_csv(
 message("[CI] Best Picture scrape complete.")
 
 message("[CI] Starting Top 1000 Box Office scrape...")
-orig_source(here::here("web_scraping", "top1000_box_office.R"), local = FALSE)
+run_with_retry(
+  "Top 1000 Box Office scrape",
+  orig_source(
+    here::here("web_scraping", "top1000_box_office.R"),
+    local = FALSE
+  )
+)
 readr::write_csv(
   imdb_rank_ratings_clean,
   here::here("data", "top1000_box_office.csv")

--- a/scripts/refresh_top250_with_rt.R
+++ b/scripts/refresh_top250_with_rt.R
@@ -5,22 +5,17 @@
 # notification step (which requires user OAuth, not available in CI) and
 # preserves the CSV write.
 #
+# IMDb intermittently returns empty / unparseable bodies to GitHub Actions
+# IPs, so the scrape is retried with backoff before we give up.
+#
 # Usage:
 #   Rscript scripts/refresh_top250_with_rt.R
 
-# Stub out the gmail helper before sourcing the scraper so it doesn't try
-# to authenticate with a missing client secret.
 send_gmail_notification <- function(...) {
   message("[CI] Skipping Gmail notification.")
   invisible(NULL)
 }
 
-# Override the source() of gmail_notify.R to a no-op when called from inside
-# the scraper. We do this by pre-creating the function in the global env;
-# the scraper's `source(... gmail_notify.R)` will overwrite it, so we also
-# defang the resulting function by wrapping the call in a tryCatch.
-#
-# Simpler: monkey-patch source() locally to skip that one file.
 orig_source <- base::source
 source <- function(file, ...) {
   if (grepl("gmail_notify\\.R$", file)) {
@@ -35,5 +30,37 @@ if (!file.exists(orig_top250)) {
   stop("Cannot find ", orig_top250, " from working directory ", getwd())
 }
 
-orig_source(orig_top250, local = FALSE)
+run_with_retry <- function(label, expr, max_attempts = 3) {
+  expr <- substitute(expr)
+  envir <- parent.frame()
+  for (attempt in seq_len(max_attempts)) {
+    res <- tryCatch(eval(expr, envir = envir), error = function(e) e)
+    if (!inherits(res, "error")) {
+      return(invisible(res))
+    }
+    msg <- conditionMessage(res)
+    message(sprintf(
+      "[CI] %s attempt %d/%d failed: %s",
+      label, attempt, max_attempts, msg
+    ))
+    cache_dir <- here::here("web_scraping", "cache")
+    if (dir.exists(cache_dir)) {
+      message("[CI] Clearing scraper cache at ", cache_dir)
+      unlink(cache_dir, recursive = TRUE, force = TRUE)
+    }
+    if (attempt < max_attempts) {
+      Sys.sleep(2 ^ attempt * 5)
+    } else {
+      stop(sprintf(
+        "%s failed after %d attempts: %s",
+        label, max_attempts, msg
+      ))
+    }
+  }
+}
+
+run_with_retry(
+  "Top 250 with Rotten Tomatoes scrape",
+  orig_source(orig_top250, local = FALSE)
+)
 message("[CI] Refresh complete: data/top250_movies_with_rt.csv")

--- a/scripts/refresh_top250_with_rt.R
+++ b/scripts/refresh_top250_with_rt.R
@@ -5,7 +5,7 @@
 # notification step (which requires user OAuth, not available in CI) and
 # preserves the CSV write.
 #
-# IMDb intermittently returns empty / unparseable bodies to GitHub Actions
+# IMDb intermittently returns empty / unparsable bodies to GitHub Actions
 # IPs, so the scrape is retried with backoff before we give up.
 #
 # Usage:


### PR DESCRIPTION
## Summary

The Top 1000 box office and Top 250 with RT refresh workflows added in #52 fail intermittently because IMDb sometimes returns empty / unparseable HTML to GitHub Actions IPs. \`xml2::read_html()\` then errors with \`Failed to parse text\` or \`'' does not exist in current working directory\`.

This wraps the underlying \`source(...)\` calls in a small retry helper:

- retries up to 3 times with exponential backoff (5s, 10s, 20s)
- clears the scraper's on-disk cache (\`web_scraping/cache/\`) between attempts so a poisoned 200-OK-with-empty-body cache entry cannot wedge subsequent attempts
- final failure still aborts the workflow with a clear error message naming the scrape

The underlying scrapers in \`web_scraping/\` are not touched; this is purely the CI wrapper layer.

## Test plan

- [x] Locally diff-checked: only \`scripts/refresh_top1000_box_office.R\` and \`scripts/refresh_top250_with_rt.R\` changed.
- [ ] Once merged, retrigger \`Refresh Top 1000 box office data\` and \`Refresh Top 250 movies with Rotten Tomatoes\` workflows and confirm they pass (or, if IMDb is broadly down, that the retry logs are produced before failing cleanly).