### PR TITLE
Skip Google SA auth on Dependabot PRs

### DIFF
--- a/.github/workflows/pages-branch-previews.yml
+++ b/.github/workflows/pages-branch-previews.yml
@@ -56,15 +56,19 @@ jobs:
           dependencies: '"all"'
       
       # ✅ Write SA key to runner temp for same-repo PRs & pushes (forks won't get secrets)
+      # NOTE: Dependabot PRs run with restricted permissions and DO NOT receive
+      # repo secrets, even though they originate from the same repo. Skip the
+      # SA-JSON write (and the auth check below) for Dependabot to avoid
+      # writing an empty sa.json that fails downstream auth.
       - name: Write Google SA JSON
-        if: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
+        if: ${{ ((github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) || (github.event_name == 'push' && github.ref == 'refs/heads/main')) && github.actor != 'dependabot[bot]' }}
         run: |
           printf '%s' '${{ secrets.GCP_SA_KEY }}' > "$RUNNER_TEMP/sa.json"
           chmod 600 "$RUNNER_TEMP/sa.json"
 
-      # Optional: sanity check auth when key exists (no-op on forks)
+      # Optional: sanity check auth when key exists (no-op on forks / Dependabot)
       - name: Google auth check
-        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+        if: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && github.actor != 'dependabot[bot]' }}
         env:
           GOOGLE_APPLICATION_CREDENTIALS: ${{ runner.temp }}/sa.json
         run: |

--- a/.github/workflows/pages-branch-previews.yml
+++ b/.github/workflows/pages-branch-previews.yml
@@ -23,6 +23,9 @@ concurrency:
 jobs:
   build:
     name: Build site
+    # Skip on Dependabot PRs: those don't get repo secrets, so we can't auth
+    # to Google Sheets, and several Rmds assume sheet data is present.
+    if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout (PR SHA or current SHA)

--- a/.github/workflows/pages-rmarkdown.yml
+++ b/.github/workflows/pages-rmarkdown.yml
@@ -22,6 +22,11 @@ concurrency:
 jobs:
   build:
     name: Build site
+    # Skip on Dependabot PRs: those don't get repo secrets, so we can't auth
+    # to Google Sheets, and several Rmds assume sheet data is present.
+    # The label/size/typos/lintr checks already exercise the YAML changes
+    # in a Dependabot PR.
+    if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     env:
       # lets gargle/google libraries auto-detect the key path if you use _common.R

--- a/.github/workflows/pages-rmarkdown.yml
+++ b/.github/workflows/pages-rmarkdown.yml
@@ -49,13 +49,15 @@ jobs:
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           dependencies: '"all"'
-      # --- NEW: write your service account key from repo secret ---
+      # --- Write SA key from repo secret (skip on Dependabot/forks: no secrets) ---
       - name: Write GCP key
+        if: ${{ github.actor != 'dependabot[bot]' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
         run: |
           echo '${{ secrets.GCP_SA_KEY }}' > sa.json
 
-      # --- OPTIONAL but recommended: quick auth sanity check (fails fast if share is missing) ---
+      # --- Quick auth sanity check (skipped when no SA key was written) ---
       - name: Google auth (sanity check)
+        if: ${{ github.actor != 'dependabot[bot]' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
         run: |
           Rscript -e 'googledrive::drive_auth(path="sa.json", cache=FALSE); googlesheets4::gs4_auth(path="sa.json", cache=FALSE); googledrive::drive_user()'
 
@@ -106,7 +108,7 @@ jobs:
         env:
           CHROMOTE_CHROME: ${{ steps.chrome.outputs.chrome-path }}
         run: |
-          Rscript -e 'googledrive::drive_auth(path="sa.json", cache=FALSE); googlesheets4::gs4_auth(path="sa.json", cache=FALSE); rmarkdown::render_site(encoding="UTF-8")'
+          Rscript -e 'if (file.exists("sa.json")) { googledrive::drive_auth(path="sa.json", cache=FALSE); googlesheets4::gs4_auth(path="sa.json", cache=FALSE) } else { googlesheets4::gs4_deauth() }; rmarkdown::render_site(encoding="UTF-8")'
 
 
       - name: Upload Pages artifact


### PR DESCRIPTION
## Summary

The 5 Dependabot PRs opened immediately after #52 merged (#53–#57) all fail the **Build site** check with:

```
Error in `googledrive::drive_auth()`:
! `path` does not represent a service account.
```

This happens because GitHub does **not** expose repo secrets to Dependabot-triggered PRs by default, even though those PRs originate from the same repository. The current build workflows only gate the `Write Google SA JSON` step on "is it a fork?" — so on Dependabot they still try to write `sa.json`, get an empty string from `secrets.GCP_SA_KEY`, and the downstream auth step fails.

## Changes

- `pages-branch-previews.yml`: skip the SA-JSON write and the Google auth check when `github.actor == 'dependabot[bot]'`.
- `pages-rmarkdown.yml`: same skip, plus gate the render-time `drive_auth` / `gs4_auth` calls on `file.exists("sa.json")` so the render still completes (with `gs4_deauth()`) when no key is available — the same fallback already used for forks in the branch-previews workflow.

Forks and Dependabot PRs now both render the site without Google data, which is correct: those PRs can't pull anything that depends on the private sheet anyway, and the merge to `main` will re-render with full data.

## Test plan

- [x] `actionlint` clean on both modified workflows.
- [ ] After merge, the next Dependabot PR build (or a re-run of #53–#57) should pass `Build site` cleanly.