### PR TITLE
Reduce automation PR noise

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,7 @@ updates:
       - "ci"
       - "dependencies"
     open-pull-requests-limit: 5
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/rebuild_cv.yml
+++ b/.github/workflows/rebuild_cv.yml
@@ -22,6 +22,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Stash existing CV files for content comparison
+        run: |
+          mkdir -p .cv-pre
+          [ -f cv.pdf ] && cp cv.pdf .cv-pre/cv.pdf || true
+          [ -f cv_doc.docx ] && cp cv_doc.docx .cv-pre/cv_doc.docx || true
+
       - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true
@@ -72,21 +78,60 @@ jobs:
         id: diff
         run: |
           set -euo pipefail
-          # PDFs and DOCX files contain creation timestamps; ignore those by
-          # extracting text and comparing. For PDF, use pdftotext if available,
-          # otherwise fall back to byte diff.
+          # Both PDF and DOCX embed regeneration timestamps that change every
+          # render even when the underlying Google Sheet hasn't been edited.
+          # Compare extractable content instead of raw bytes:
+          #   - DOCX: unzip and compare word/document.xml (the visible body)
+          #   - PDF:  use pdftotext to compare extracted text
+          # If content is unchanged, restore the prior bytes so the PR step
+          # below sees a clean working tree and skips opening a noise PR.
+
+          sudo apt-get update -qq && sudo apt-get install -y -qq poppler-utils
+
           changed=""
-          for f in cv.pdf cv_doc.docx; do
-            if [ -f "$f" ] && ! git diff --quiet -- "$f"; then
-              changed="$changed $f"
+
+          # ---- DOCX content compare ----
+          if [ -f cv_doc.docx ]; then
+            if [ -f .cv-pre/cv_doc.docx ]; then
+              old_xml="$(unzip -p .cv-pre/cv_doc.docx word/document.xml || echo "")"
+              new_xml="$(unzip -p cv_doc.docx word/document.xml || echo "")"
+              if [ "$old_xml" = "$new_xml" ]; then
+                echo "cv_doc.docx: content unchanged (timestamp-only diff); reverting."
+                cp .cv-pre/cv_doc.docx cv_doc.docx
+              else
+                echo "cv_doc.docx: content changed."
+                changed="$changed cv_doc.docx"
+              fi
+            else
+              changed="$changed cv_doc.docx"
             fi
-          done
+          fi
+
+          # ---- PDF content compare ----
+          if [ -f cv.pdf ]; then
+            if [ -f .cv-pre/cv.pdf ]; then
+              old_txt="$(pdftotext -layout .cv-pre/cv.pdf - 2>/dev/null || echo "")"
+              new_txt="$(pdftotext -layout cv.pdf - 2>/dev/null || echo "")"
+              if [ "$old_txt" = "$new_txt" ]; then
+                echo "cv.pdf: text unchanged (likely timestamp-only diff); reverting."
+                cp .cv-pre/cv.pdf cv.pdf
+              else
+                echo "cv.pdf: text changed."
+                changed="$changed cv.pdf"
+              fi
+            else
+              changed="$changed cv.pdf"
+            fi
+          fi
+
+          rm -rf .cv-pre
+
           if [ -z "$changed" ]; then
             echo "changed=" >> "$GITHUB_OUTPUT"
-            echo "No CV file changes detected."
+            echo "No meaningful CV content changes detected."
           else
             echo "changed=$changed" >> "$GITHUB_OUTPUT"
-            echo "Changed: $changed"
+            echo "Meaningful changes:$changed"
           fi
 
       - name: Open PR if CV files changed

--- a/.github/workflows/refresh-sitemap.yml
+++ b/.github/workflows/refresh-sitemap.yml
@@ -7,7 +7,6 @@ on:
 
 permissions:
   contents: write
-  pull-requests: write
 
 concurrency:
   group: refresh-sitemap
@@ -35,18 +34,22 @@ jobs:
       - name: Regenerate sitemap.xml
         run: Rscript scripts/generate_sitemap.R
 
-      - name: Open PR if sitemap changed
-        uses: peter-evans/create-pull-request@v6
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          branch: auto/refresh-sitemap
-          delete-branch: true
-          commit-message: "Refresh sitemap.xml"
-          title: "Refresh sitemap.xml"
-          body: |
-            Auto-regenerated `sitemap.xml` from `_site.yml` and the rendered site.
-          add-paths: |
-            sitemap.xml
-          labels: |
-            ci
-            automated
+      - name: Commit and push if sitemap changed
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add sitemap.xml
+          if git diff --cached --quiet; then
+            echo "No sitemap changes."
+            exit 0
+          fi
+          git commit -m "Auto-refresh sitemap.xml"
+          # Pull-rebase to avoid losing races with other refresh workflows.
+          for i in 1 2 3; do
+            if git push; then exit 0; fi
+            echo "Push failed; rebasing on remote and retrying ($i/3)..."
+            git pull --rebase origin "$(git rev-parse --abbrev-ref HEAD)"
+          done
+          echo "ERROR: failed to push sitemap update after 3 attempts."
+          exit 1

--- a/.github/workflows/update_sp500.yml
+++ b/.github/workflows/update_sp500.yml
@@ -56,4 +56,10 @@ jobs:
             exit 0
           fi
           git commit -m "Auto-update VOO stock prices"
-          git push
+          for i in 1 2 3; do
+            if git push; then exit 0; fi
+            echo "Push failed; rebasing on remote and retrying ($i/3)..."
+            git pull --rebase origin "$(git rev-parse --abbrev-ref HEAD)"
+          done
+          echo "ERROR: failed to push VOO update after 3 attempts."
+          exit 1

--- a/.github/workflows/update_top1000_box_office.yml
+++ b/.github/workflows/update_top1000_box_office.yml
@@ -65,4 +65,10 @@ jobs:
             exit 0
           fi
           git commit -m "Auto-update Top 1000 box office + Best Picture data"
-          git push
+          for i in 1 2 3; do
+            if git push; then exit 0; fi
+            echo "Push failed; rebasing on remote and retrying ($i/3)..."
+            git pull --rebase origin "$(git rev-parse --abbrev-ref HEAD)"
+          done
+          echo "ERROR: failed to push box office update after 3 attempts."
+          exit 1

--- a/.github/workflows/update_top250_with_rt.yml
+++ b/.github/workflows/update_top250_with_rt.yml
@@ -65,4 +65,10 @@ jobs:
             exit 0
           fi
           git commit -m "Auto-update Top 250 movies with Rotten Tomatoes"
-          git push
+          for i in 1 2 3; do
+            if git push; then exit 0; fi
+            echo "Push failed; rebasing on remote and retrying ($i/3)..."
+            git pull --rebase origin "$(git rev-parse --abbrev-ref HEAD)"
+          done
+          echo "ERROR: failed to push Top 250 update after 3 attempts."
+          exit 1

--- a/.github/workflows/update_us_rentals.yml
+++ b/.github/workflows/update_us_rentals.yml
@@ -58,4 +58,10 @@ jobs:
             exit 0
           fi
           git commit -m "Auto-update US rental markets data"
-          git push
+          for i in 1 2 3; do
+            if git push; then exit 0; fi
+            echo "Push failed; rebasing on remote and retrying ($i/3)..."
+            git pull --rebase origin "$(git rev-parse --abbrev-ref HEAD)"
+          done
+          echo "ERROR: failed to push rentals update after 3 attempts."
+          exit 1


### PR DESCRIPTION
## Summary

Three changes that together cut the rate of automation-opened PRs roughly in half (and eliminate one whole class of noise PR entirely):

### 1. CV rebuild: content-aware diff

The daily *Rebuild CV* workflow was opening a PR almost every run because pandoc embeds a fresh `created`/`modified` timestamp inside the docx metadata. The bytes always differ even when the underlying Google Sheet hasn't been edited.

[#60](https://github.com/cavandonohoe/cavandonohoe.github.io/pull/60) is a perfect example: the only thing that actually changed in `cv_doc.docx` was these two lines inside `docProps/core.xml`:

```diff
-<dcterms:created>2025-12-29T19:04:24Z</dcterms:created>
-<dcterms:modified>2025-12-29T19:04:24Z</dcterms:modified>
+<dcterms:created>2026-05-26T14:16:12Z</dcterms:created>
+<dcterms:modified>2026-05-26T14:16:12Z</dcterms:modified>
```

The new diff step:
- Stashes the prior `cv.pdf` / `cv_doc.docx` before the render
- Compares `word/document.xml` (the visible body) for the docx
- Compares `pdftotext -layout` output for the pdf
- If content matches, restores the prior bytes so the working tree is clean and no PR is opened

I tested the docx logic locally against the actual #60 files and confirmed it correctly identifies "no real change."

### 2. Dependabot: group all GitHub Actions bumps

The first Dependabot run opened five PRs at once (one per action: setup-node, deploy-pages, upload-artifact, create-pull-request, peaceiris). With:

```yaml
groups:
  github-actions:
    patterns:
      - "*"
```

it'll now batch them into a single weekly PR.

### 3. Mechanical data refreshes: direct push + pull-rebase retry

- `refresh-sitemap` switched from PR-creating to direct push (matches the other refresh workflows).
- Added a 3-attempt `git pull --rebase` / `git push` loop to:
  - `refresh-sitemap.yml`
  - `update_sp500.yml`
  - `update_us_rentals.yml`
  - `update_top250_with_rt.yml`
  - `update_top1000_box_office.yml`

This fixes the push-race we hit on S&P 500 right after #52 merged (parallel data-refresh workflows pushing to `main` simultaneously).

## Out of scope (intentionally)

- `update_best_picture_winners.yml` still opens PRs. It was the original pattern before #52 and only fires once a year (Oscars). Leaving it alone unless you want the same treatment.
- The CV workflow still opens a PR when content actually changes — just not on timestamp-only diffs.

## Test plan

- [x] `actionlint` clean on all 6 modified workflows.
- [x] `python3 -c 'yaml.safe_load(...)'` clean on `dependabot.yml`.
- [x] Local smoke test: ran the docx-content-compare logic against #60's old vs new docx; confirmed it identifies them as content-equal.
- [ ] After merge: close #60 manually (it's a no-op anyway). Next CV rebuild run should report "No meaningful CV content changes detected" and not open a PR.
- [ ] After merge: next Dependabot run should produce one grouped PR instead of N.