### PR TITLE
Bump GitHub Actions to Node 24-compatible majors

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -12,7 +12,7 @@ jobs:
   label:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@v5
+      - uses: actions/labeler@v6
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           sync-labels: true

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Download site artifact from triggering workflow
         uses: dawidd6/action-download-artifact@v6
@@ -42,7 +42,7 @@ jobs:
             echo "have_site=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         if: steps.presence.outputs.have_site == 'true'
         with:
           node-version: "20"
@@ -107,7 +107,7 @@ jobs:
 
       - name: Upload Lighthouse logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: lighthouse-logs
           path: |

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Try to download latest built site artifact (optional)
         id: artifact
@@ -67,7 +67,7 @@ jobs:
           fail: false
 
       - name: Upload report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: ${{ hashFiles('lychee-report.md') != '' }}
         with:
           name: lychee-report

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/pa11y.yml
+++ b/.github/workflows/pa11y.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Download latest built site
         uses: dawidd6/action-download-artifact@v6
@@ -29,7 +29,7 @@ jobs:
           branch: main
           if_no_artifact_found: fail
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: "20"
 
@@ -88,7 +88,7 @@ jobs:
 
       - name: Upload report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: pa11y-report
           path: |

--- a/.github/workflows/pages-branch-previews.yml
+++ b/.github/workflows/pages-branch-previews.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout (PR SHA or current SHA)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.sha }}
 
@@ -108,7 +108,7 @@ jobs:
           fi
 
       - name: Upload built site
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: site
           path: _site
@@ -127,7 +127,7 @@ jobs:
       group: gh-pages-deploy
       cancel-in-progress: false
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v7
         with:
           name: site
           path: _site
@@ -154,7 +154,7 @@ jobs:
       group: gh-pages-deploy
       cancel-in-progress: false
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v7
         with:
           name: site
           path: _site
@@ -186,7 +186,7 @@ jobs:
       cancel-in-progress: false
     steps:
       - name: Checkout gh-pages
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: gh-pages
       - name: Delete folder and push

--- a/.github/workflows/pages-branch-previews.yml
+++ b/.github/workflows/pages-branch-previews.yml
@@ -132,7 +132,7 @@ jobs:
           name: site
           path: _site
       - name: Publish to gh-pages root
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_branch: gh-pages
@@ -159,7 +159,7 @@ jobs:
           name: site
           path: _site
       - name: Publish PR preview folder
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_branch: gh-pages

--- a/.github/workflows/pages-rmarkdown.yml
+++ b/.github/workflows/pages-rmarkdown.yml
@@ -32,7 +32,7 @@ jobs:
       # lets gargle/google libraries auto-detect the key path if you use _common.R
       GOOGLE_APPLICATION_CREDENTIALS: ${{ github.workspace }}/sa.json
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: r-lib/actions/setup-r@v2
         with:
@@ -137,7 +137,7 @@ jobs:
     steps:
       - name: Deploy
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5
       
       - name: Comment preview URL
         if: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/pr-smoke.yml
+++ b/.github/workflows/pr-smoke.yml
@@ -25,7 +25,7 @@ jobs:
       GOOGLE_APPLICATION_CREDENTIALS: ${{ github.workspace }}/sa.json
       CI: "true"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/rebuild_cv.yml
+++ b/.github/workflows/rebuild_cv.yml
@@ -20,7 +20,7 @@ jobs:
     env:
       GOOGLE_APPLICATION_CREDENTIALS: ${{ github.workspace }}/sa.json
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Stash existing CV files for content comparison
         run: |
@@ -136,7 +136,7 @@ jobs:
 
       - name: Open PR if CV files changed
         if: ${{ steps.diff.outputs.changed != '' }}
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: auto/rebuild-cv

--- a/.github/workflows/refresh-sitemap.yml
+++ b/.github/workflows/refresh-sitemap.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: r-lib/actions/setup-r@v2
         with:

--- a/.github/workflows/repo-size.yml
+++ b/.github/workflows/repo-size.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 1
 
@@ -81,7 +81,7 @@ jobs:
           cat size-report.md
 
       - name: Upload report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: size-report
           path: size-report.md

--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: crate-ci/typos@master
         with:
           config: .typos.toml

--- a/.github/workflows/update_best_picture_winners.yml
+++ b/.github/workflows/update_best_picture_winners.yml
@@ -13,7 +13,7 @@ jobs:
   update:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: r-lib/actions/setup-r@v2
         with:
@@ -27,7 +27,7 @@ jobs:
         run: Rscript scripts/check_best_picture_winners.R
 
       - name: Open PR if data changed
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: auto/update-best-picture-winners

--- a/.github/workflows/update_imdb_ratings.yml
+++ b/.github/workflows/update_imdb_ratings.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: r-lib/actions/setup-r@v2
         with:

--- a/.github/workflows/update_mymaps_export.yml
+++ b/.github/workflows/update_mymaps_export.yml
@@ -12,7 +12,7 @@ jobs:
   update:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Download KML
         run: |

--- a/.github/workflows/update_sp500.yml
+++ b/.github/workflows/update_sp500.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: r-lib/actions/setup-r@v2
         with:

--- a/.github/workflows/update_top1000_box_office.yml
+++ b/.github/workflows/update_top1000_box_office.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: r-lib/actions/setup-r@v2
         with:

--- a/.github/workflows/update_top250_with_rt.yml
+++ b/.github/workflows/update_top250_with_rt.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 90
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: r-lib/actions/setup-r@v2
         with:

--- a/.github/workflows/update_us_rentals.yml
+++ b/.github/workflows/update_us_rentals.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: r-lib/actions/setup-r@v2
         with:


### PR DESCRIPTION
## Summary

GitHub is forcing all Node 20 actions to run on Node 24 by default starting **June 2nd, 2026**. Bump the action majors that are still pinned to Node 20 to their first Node 24 major:

| Action | Old | New |
|---|---|---|
| `actions/checkout` | `@v4` | `@v5` |
| `actions/upload-artifact` | `@v4` | `@v6` |
| `actions/download-artifact` | `@v4` | `@v7` |
| `actions/setup-node` | `@v4` | `@v5` |
| `actions/deploy-pages` | `@v4` | `@v5` |
| `actions/labeler` | `@v5` | `@v6` |
| `peter-evans/create-pull-request` | `@v6` | `@v8` |
| `peaceiris/actions-gh-pages` | `@v3` | `@v4` |

Supersedes Dependabot PRs #53, #54, #55, #56, #57 (each opened individually before the grouping config landed).

## Compatibility check

No input-shape changes are needed for our usage:

- `peter-evans/create-pull-request@v7` renamed `git-token` to `branch-token` — we don't set that input anywhere (we rely on the default `GITHUB_TOKEN`).
- `actions/setup-node@v5` adds automatic caching when `packageManager` is set in a root `package.json`. Our two `setup-node` calls (`pa11y.yml`, `lighthouse.yml`) install global tools; there's no root `package.json` so the new behavior is a no-op.
- `peaceiris/actions-gh-pages@v4` is just a Node 16 → Node 20 runtime bump with no input changes.
- All bumped actions require runner `v2.327.1+`, which github-hosted runners already have.

Untouched actions either already run on Node 24 (e.g., `r-lib/actions/*@v2`, `lycheeverse/lychee-action@v2`, `dawidd6/action-download-artifact@v6`, `peter-evans/create-issue-from-file@v5`, `actions/upload-pages-artifact@v3`) or are composite actions (no Node runtime).

## Test plan

- [ ] Build site (PR preview) passes
- [ ] All other workflows still run (lint, typos, link-check, lighthouse, pa11y, repo-size)
- [ ] No deprecation warnings in run logs