### PR TITLE
Bump thollander/actions-comment-pull-request v2 -> v3

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -96,14 +96,14 @@ jobs:
 
       - name: Comment on PR
         if: ${{ steps.presence.outputs.have_site == 'true' && steps.pr.outputs.number != '' }}
-        uses: thollander/actions-comment-pull-request@v2
+        uses: thollander/actions-comment-pull-request@v3
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          pr_number: ${{ steps.pr.outputs.number }}
-          filePath: ./lhci-comment.md
-          comment_tag: lighthouse-ci
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          pr-number: ${{ steps.pr.outputs.number }}
+          file-path: ./lhci-comment.md
+          comment-tag: lighthouse-ci
           mode: upsert
-          create_if_not_exists: true
+          create-if-not-exists: true
 
       - name: Upload Lighthouse logs
         if: always()

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -85,10 +85,10 @@ jobs:
 
       - name: Comment on PR
         if: ${{ github.event_name == 'pull_request' && hashFiles('lychee-report.md') != '' }}
-        uses: thollander/actions-comment-pull-request@v2
+        uses: thollander/actions-comment-pull-request@v3
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          filePath: ./lychee-report.md
-          comment_tag: lychee-link-check
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          file-path: ./lychee-report.md
+          comment-tag: lychee-link-check
           mode: upsert
-          create_if_not_exists: true
+          create-if-not-exists: true

--- a/.github/workflows/pages-branch-previews.yml
+++ b/.github/workflows/pages-branch-previews.yml
@@ -169,12 +169,12 @@ jobs:
           exclude_assets: 'sa.json'
       - name: Comment preview URL
         if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
-        uses: thollander/actions-comment-pull-request@v2
+        uses: thollander/actions-comment-pull-request@v3
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           message: "🚀 Preview: https://cavandonohoe.github.io/pr-${{ github.event.pull_request.number }}/"
           mode: upsert
-          create_if_not_exists: true
+          create-if-not-exists: true
 
   # CLEANUP: delete subfolder when PR closes
   cleanup_preview:

--- a/.github/workflows/pages-rmarkdown.yml
+++ b/.github/workflows/pages-rmarkdown.yml
@@ -141,9 +141,9 @@ jobs:
       
       - name: Comment preview URL
         if: ${{ github.event_name == 'pull_request' }}
-        uses: thollander/actions-comment-pull-request@v2
+        uses: thollander/actions-comment-pull-request@v3
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           message: "🚀 Preview: ${{ steps.deployment.outputs.page_url }}"
           mode: upsert
-          create_if_not_exists: true
+          create-if-not-exists: true

--- a/.github/workflows/repo-size.yml
+++ b/.github/workflows/repo-size.yml
@@ -88,13 +88,13 @@ jobs:
 
       - name: Comment on PR
         if: ${{ github.event_name == 'pull_request' }}
-        uses: thollander/actions-comment-pull-request@v2
+        uses: thollander/actions-comment-pull-request@v3
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          filePath: ./size-report.md
-          comment_tag: repo-size
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          file-path: ./size-report.md
+          comment-tag: repo-size
           mode: upsert
-          create_if_not_exists: true
+          create-if-not-exists: true
 
       - name: Open issue if scheduled run exceeded threshold
         if: ${{ github.event_name == 'schedule' && steps.report.outputs.exceeded == 'true' }}


### PR DESCRIPTION
## Summary

Finishes the Dependabot grouped-bump that PR #65 deliberately deferred. The Dependabot proposal in #66 failed CI because `thollander/actions-comment-pull-request@v3` renames every input but the workflows still used the old names, producing:

> ##[error]Either "filePath" or "message" should be provided as input unless running as "delete".

This PR bumps to `@v3` and renames the inputs in all five workflows that use it:

| Old | New |
|---|---|
| `GITHUB_TOKEN` | `github-token` |
| `filePath` | `file-path` |
| `pr_number` | `pr-number` |
| `comment_tag` | `comment-tag` |
| `create_if_not_exists` | `create-if-not-exists` |

`message`, `mode`, and the `upsert` value are unchanged.

Affected workflows:
- `.github/workflows/lighthouse.yml`
- `.github/workflows/link-check.yml`
- `.github/workflows/pages-rmarkdown.yml`
- `.github/workflows/pages-branch-previews.yml`
- `.github/workflows/repo-size.yml`

## Also fixed (out-of-band)

The repo was missing the `dependencies` label that `dependabot.yml` and `.github/labeler.yml` both reference. Created it via the API (no file change needed):

```
gh api -X POST repos/cavandonohoe/cavandonohoe.github.io/labels \
  -f name='dependencies' -f color='0366d6' \
  -f description='Pull requests that update a dependency file'
```

This stops the "The following labels could not be found: dependencies" config-error comment that was appearing on every Dependabot PR.

## Test plan

- [ ] All standard checks pass on this PR (lighthouse skipped if no site presence change, link-check posts a comment, repo-size posts a comment)
- [ ] PR preview comment from `pages-branch-previews` appears with the v3 action
- [ ] No `Unexpected input(s)` warnings in any of the affected workflow logs