### PR TITLE
Soft-fail IMDb scrapes when GH Actions IPs are blocked

### DIFF
--- a/scripts/_scrape_retry.R
+++ b/scripts/_scrape_retry.R
@@ -1,20 +1,47 @@
 #!/usr/bin/env Rscript
 # scripts/_scrape_retry.R
 #
-# Shared helper for CI-driven scrapers that hit IMDb / Rotten Tomatoes /
+# Shared helpers for CI-driven scrapers that hit IMDb / Rotten Tomatoes /
 # similar sites and intermittently get empty or malformed bodies from
 # anti-bot infrastructure on GitHub Actions IPs.
 #
-# Source this file from refresh_*.R wrappers (or any CI script) and call
-# `run_with_retry(label, expr)`.
+# Source this file from refresh_*.R / check_*.R wrappers (or any CI
+# script) and call:
+#   - run_with_retry(label, expr): retry expr up to 3 times, clearing
+#     the scraper cache between attempts. Re-raises on terminal failure.
+#   - signal_imdb_block(url): throw a typed condition the wrappers can
+#     catch and turn into a soft failure when IMDb is actively blocking
+#     GH Actions IPs (HTTP 200 with 0-byte body).
+#   - run_or_softfail_on_imdb_block(label, expr): wrap a scrape so that
+#     an `imdb_blocked` condition becomes an annotated success (exit 0
+#     with a GITHUB_STEP_SUMMARY note) instead of a red CI failure. Any
+#     other error still propagates.
+
+signal_imdb_block <- function(url) {
+  cond <- structure(
+    class = c("imdb_blocked", "condition"),
+    list(
+      message = sprintf(
+        "IMDb returned 0-byte body for %s after all retries (anti-bot block)",
+        url
+      ),
+      call = sys.call(-1),
+      url = url
+    )
+  )
+  stop(cond)
+}
 
 run_with_retry <- function(label, expr, max_attempts = 3) {
   expr <- substitute(expr)
   envir <- parent.frame()
   for (attempt in seq_len(max_attempts)) {
     res <- tryCatch(eval(expr, envir = envir), error = function(e) e)
-    if (!inherits(res, "error")) {
+    if (!inherits(res, "error") && !inherits(res, "condition")) {
       return(invisible(res))
+    }
+    if (inherits(res, "imdb_blocked")) {
+      stop(res)
     }
     msg <- conditionMessage(res)
     message(sprintf(
@@ -36,3 +63,45 @@ run_with_retry <- function(label, expr, max_attempts = 3) {
     }
   }
 }
+
+write_step_summary <- function(lines) {
+  path <- Sys.getenv("GITHUB_STEP_SUMMARY")
+  if (!nzchar(path)) {
+    message(paste(lines, collapse = "\n"))
+    return(invisible(NULL))
+  }
+  cat(paste(lines, collapse = "\n"), "\n",
+    file = path, append = TRUE, sep = "")
+}
+
+run_or_softfail_on_imdb_block <- function(label, expr) {
+  expr <- substitute(expr)
+  envir <- parent.frame()
+  res <- tryCatch(
+    eval(expr, envir = envir),
+    imdb_blocked = function(c) c,
+    error = function(e) e
+  )
+  if (inherits(res, "imdb_blocked")) {
+    message(sprintf(
+      "[CI] %s soft-failed: %s",
+      label, conditionMessage(res)
+    ))
+    write_step_summary(c(
+      sprintf("## %s skipped: IMDb anti-bot block", label),
+      "",
+      sprintf("- URL: `%s`", res$url %||% "(unknown)"),
+      "- IMDb returned HTTP 200 with a 0-byte body for every retry.",
+      "- Existing data file is preserved; will refresh on the next run",
+      "  once IMDb releases the block on GitHub Actions IPs.",
+      ""
+    ))
+    return(structure(list(blocked = TRUE), class = "imdb_block_softfail"))
+  }
+  if (inherits(res, "error")) {
+    stop(res)
+  }
+  invisible(structure(list(blocked = FALSE), class = "imdb_block_success"))
+}
+
+`%||%` <- function(a, b) if (is.null(a)) b else a

--- a/scripts/_scrape_retry.R
+++ b/scripts/_scrape_retry.R
@@ -19,7 +19,7 @@
 
 signal_imdb_block <- function(url) {
   cond <- structure(
-    class = c("imdb_blocked", "condition"),
+    class = c("imdb_blocked", "error", "condition"),
     list(
       message = sprintf(
         "IMDb returned 0-byte body for %s after all retries (anti-bot block)",

--- a/scripts/check_best_picture_winners.R
+++ b/scripts/check_best_picture_winners.R
@@ -15,10 +15,17 @@ box_office_cache_path <- cache_path
 source(here::here("scripts", "_scrape_retry.R"))
 
 message("Refreshing Best Picture winners from IMDb...")
-run_with_retry(
+bp_result <- run_or_softfail_on_imdb_block(
   "Best Picture winners scrape",
-  source(here::here("web_scraping", "best_picture_winners.R"))
+  run_with_retry(
+    "Best Picture winners scrape",
+    source(here::here("web_scraping", "best_picture_winners.R"))
+  )
 )
+if (inherits(bp_result, "imdb_block_softfail")) {
+  message("Best Picture scrape skipped (IMDb block); existing CSV unchanged.")
+  quit(save = "no", status = 0)
+}
 
 new_winners <- oscar_winners_clean
 readr::write_csv(new_winners, csv_path)

--- a/scripts/refresh_top1000_box_office.R
+++ b/scripts/refresh_top1000_box_office.R
@@ -33,29 +33,43 @@ refresh_ratings <- FALSE
 source(here::here("scripts", "_scrape_retry.R"))
 
 message("[CI] Starting Best Picture scrape...")
-run_with_retry(
+bp_result <- run_or_softfail_on_imdb_block(
   "Best Picture scrape",
-  orig_source(
-    here::here("web_scraping", "best_picture_winners.R"),
-    local = FALSE
+  run_with_retry(
+    "Best Picture scrape",
+    orig_source(
+      here::here("web_scraping", "best_picture_winners.R"),
+      local = FALSE
+    )
   )
 )
-readr::write_csv(
-  oscar_winners_clean,
-  here::here("data", "best_picture_winners.csv")
-)
-message("[CI] Best Picture scrape complete.")
+if (!inherits(bp_result, "imdb_block_softfail")) {
+  readr::write_csv(
+    oscar_winners_clean,
+    here::here("data", "best_picture_winners.csv")
+  )
+  message("[CI] Best Picture scrape complete.")
+} else {
+  message("[CI] Best Picture scrape skipped (IMDb block); CSV unchanged.")
+}
 
 message("[CI] Starting Top 1000 Box Office scrape...")
-run_with_retry(
+bo_result <- run_or_softfail_on_imdb_block(
   "Top 1000 Box Office scrape",
-  orig_source(
-    here::here("web_scraping", "top1000_box_office.R"),
-    local = FALSE
+  run_with_retry(
+    "Top 1000 Box Office scrape",
+    orig_source(
+      here::here("web_scraping", "top1000_box_office.R"),
+      local = FALSE
+    )
   )
 )
-readr::write_csv(
-  imdb_rank_ratings_clean,
-  here::here("data", "top1000_box_office.csv")
-)
-message("[CI] Top 1000 Box Office scrape complete.")
+if (!inherits(bo_result, "imdb_block_softfail")) {
+  readr::write_csv(
+    imdb_rank_ratings_clean,
+    here::here("data", "top1000_box_office.csv")
+  )
+  message("[CI] Top 1000 Box Office scrape complete.")
+} else {
+  message("[CI] Top 1000 Box Office scrape skipped (IMDb block); CSV unchanged.")
+}

--- a/scripts/refresh_top250_with_rt.R
+++ b/scripts/refresh_top250_with_rt.R
@@ -32,8 +32,15 @@ if (!file.exists(orig_top250)) {
 
 source(here::here("scripts", "_scrape_retry.R"))
 
-run_with_retry(
+t250_result <- run_or_softfail_on_imdb_block(
   "Top 250 with Rotten Tomatoes scrape",
-  orig_source(orig_top250, local = FALSE)
+  run_with_retry(
+    "Top 250 with Rotten Tomatoes scrape",
+    orig_source(orig_top250, local = FALSE)
+  )
 )
-message("[CI] Refresh complete: data/top250_movies_with_rt.csv")
+if (inherits(t250_result, "imdb_block_softfail")) {
+  message("[CI] Top 250 scrape skipped (IMDb block); CSV unchanged.")
+} else {
+  message("[CI] Refresh complete: data/top250_movies_with_rt.csv")
+}

--- a/web_scraping/best_picture_winners.R
+++ b/web_scraping/best_picture_winners.R
@@ -8,6 +8,7 @@ imdb_user_agent <- paste(
 )
 
 read_imdb_html <- function(url) {
+  all_empty <- TRUE
   for (attempt in seq_len(3)) {
     response <- tryCatch(
       httr::GET(
@@ -19,6 +20,7 @@ read_imdb_html <- function(url) {
       error = function(e) e
     )
     if (inherits(response, "error") || httr::http_error(response)) {
+      all_empty <- FALSE
       if (attempt < 3) Sys.sleep(2 ^ attempt)
       next
     }
@@ -35,11 +37,15 @@ read_imdb_html <- function(url) {
     if (!inherits(parsed, "error")) {
       return(parsed)
     }
+    all_empty <- FALSE
     message(sprintf(
       "[best_picture] parse error for %s: %s",
       url, conditionMessage(parsed)
     ))
     if (attempt < 3) Sys.sleep(2 ^ attempt)
+  }
+  if (all_empty && exists("signal_imdb_block", mode = "function")) {
+    signal_imdb_block(url)
   }
   stop("Failed to fetch ", url, " after 3 attempts")
 }

--- a/web_scraping/top1000_box_office.R
+++ b/web_scraping/top1000_box_office.R
@@ -15,6 +15,7 @@ imdb_user_agent <- paste(
 )
 
 read_imdb_html <- function(url) {
+  all_empty <- TRUE
   for (attempt in seq_len(3)) {
     response <- tryCatch(
       httr::GET(
@@ -26,6 +27,7 @@ read_imdb_html <- function(url) {
       error = function(e) e
     )
     if (inherits(response, "error") || httr::http_error(response)) {
+      all_empty <- FALSE
       if (attempt < 3) Sys.sleep(2 ^ attempt)
       next
     }
@@ -42,16 +44,21 @@ read_imdb_html <- function(url) {
     if (!inherits(parsed, "error")) {
       return(parsed)
     }
+    all_empty <- FALSE
     message(sprintf(
       "[top1000] parse error for %s: %s",
       url, conditionMessage(parsed)
     ))
     if (attempt < 3) Sys.sleep(2 ^ attempt)
   }
+  if (all_empty && exists("signal_imdb_block", mode = "function")) {
+    signal_imdb_block(url)
+  }
   stop("Failed to fetch ", url, " after 3 attempts")
 }
 
 safe_read_html <- function(page_url) {
+  all_empty <- TRUE
   for (attempt in seq_len(3)) {
     response <- tryCatch(
       httr::GET(
@@ -63,6 +70,7 @@ safe_read_html <- function(page_url) {
       error = function(e) e
     )
     if (inherits(response, "error") || httr::http_error(response)) {
+      all_empty <- FALSE
       if (attempt < 3) Sys.sleep(2 ^ attempt)
       next
     }
@@ -79,7 +87,11 @@ safe_read_html <- function(page_url) {
     if (!inherits(parsed, "error")) {
       return(parsed)
     }
+    all_empty <- FALSE
     if (attempt < 3) Sys.sleep(2 ^ attempt)
+  }
+  if (all_empty && exists("signal_imdb_block", mode = "function")) {
+    signal_imdb_block(page_url)
   }
   stop("Failed to fetch ", page_url, " after 3 attempts")
 }

--- a/web_scraping/top250_movies_with_rt.R
+++ b/web_scraping/top250_movies_with_rt.R
@@ -28,6 +28,7 @@ safe_fetch_html <- function(page_url, label = "page", max_attempts = 3, use_cach
     return(rvest::read_html(cache_path))
   }
 
+  all_empty <- TRUE
   for (attempt in seq_len(max_attempts)) {
     resp <- tryCatch(
       httr::GET(
@@ -41,9 +42,6 @@ safe_fetch_html <- function(page_url, label = "page", max_attempts = 3, use_cach
 
     if (!inherits(resp, "error") && !httr::http_error(resp)) {
       html <- httr::content(resp, as = "text", encoding = "UTF-8")
-      # Treat empty / suspiciously short bodies as a transient failure: do
-      # not cache, do not parse, just retry. IMDb anti-bot infra often
-      # returns HTTP 200 with an empty body to GitHub Actions IPs.
       if (is.null(html) || !nzchar(html) || nchar(html) < 200) {
         message(sprintf(
           "[%s] empty/short body (%d chars), retrying...",
@@ -57,6 +55,7 @@ safe_fetch_html <- function(page_url, label = "page", max_attempts = 3, use_cach
         if (!inherits(parsed, "error")) {
           return(parsed)
         }
+        all_empty <- FALSE
         message(sprintf(
           "[%s] read_html parse error: %s",
           label, conditionMessage(parsed)
@@ -65,6 +64,8 @@ safe_fetch_html <- function(page_url, label = "page", max_attempts = 3, use_cach
           unlink(cache_path)
         }
       }
+    } else {
+      all_empty <- FALSE
     }
 
     if (attempt < max_attempts) {
@@ -72,6 +73,9 @@ safe_fetch_html <- function(page_url, label = "page", max_attempts = 3, use_cach
     }
   }
 
+  if (all_empty && exists("signal_imdb_block", mode = "function")) {
+    signal_imdb_block(page_url)
+  }
   message("Failed to fetch ", label, ": ", page_url)
   NULL
 }


### PR DESCRIPTION
## Why

After [#69](https://github.com/cavandonohoe/cavandonohoe.github.io/pull/69) made the data-refresh workflows retry-resilient, three of them were *still* failing every run. Probing IMDb directly from a runner over a 24-hour window confirmed it's not a flake — IMDb's anti-bot infrastructure is consistently returning **HTTP 200 with a 0-byte body** for `/search/` and `/chart/top/` URLs from GitHub Actions IP ranges:

```
[best_picture] empty/short body for https://www.imdb.com/search/title/?... (0 chars), retrying...
[best_picture] empty/short body ... (0 chars), retrying...
[best_picture] empty/short body ... (0 chars), retrying...
[CI] Best Picture scrape attempt 3/3 failed: ...
```

No retry budget fixes that. The choices are: (a) build out a proxy / paid scraping infra, (b) leave the workflows red, or (c) make the scrapes **soft-fail when, and only when, the failure mode is a sustained empty-body block** — which is what this PR does.

The `update_imdb_ratings` workflow is unaffected because it uses the OMDb API (key-authenticated, no scraping).

## What

### Typed condition + dispatcher (`scripts/_scrape_retry.R`)

- `signal_imdb_block(url)` — raises a typed `imdb_blocked` condition.
- `run_with_retry()` re-raises `imdb_blocked` immediately (no point retrying when the inner fetcher already exhausted its own retry budget on empties).
- `run_or_softfail_on_imdb_block(label, expr)` — catches `imdb_blocked`, writes a `GITHUB_STEP_SUMMARY` annotation, and returns a sentinel `imdb_block_softfail` object so callers know to skip downstream work. Any **other** error still propagates as a hard failure.

### Inner scrapers track failure mode

`best_picture_winners.R`, `top1000_box_office.R`, `top250_movies_with_rt.R`:

- Track per-attempt failure cause with an `all_empty` flag.
- HTTP error, parse error, or anything non-empty flips the flag to `FALSE`.
- Only call `signal_imdb_block(url)` if **100% of attempts** were empty-body — i.e., the unmistakable signature of an anti-bot block.

### Wrappers handle the sentinel

`refresh_top1000_box_office.R`, `refresh_top250_with_rt.R`, `check_best_picture_winners.R`:

- Wrap each scrape in `run_or_softfail_on_imdb_block()`.
- On soft-fail: log, skip the CSV write, exit 0. Existing data file is preserved.
- On success: behave exactly as before.

## How this prevents data rot

A real bug — empty `__NEXT_DATA__`, malformed HTML, HTTP 500, missing column, parse failure, etc. — still hard-fails. Only the specific "100% empty bodies = blocked" pattern soft-fails. So if the scraper itself breaks, you'll still get a red X.

The `GITHUB_STEP_SUMMARY` annotation makes the soft-fail visible on every blocked run, so it's not silent rot. When IMDb releases the block, the next scheduled run will pick up automatically.

## Test plan

- [x] Local unit test: synthetic `signal_imdb_block()` returns a sentinel in ~20ms and writes the step-summary text.
- [x] Local unit test: a synthetic `stop("a real bug")` still propagates as a hard failure through `run_with_retry` + `run_or_softfail_on_imdb_block`.
- [x] All 7 modified R files parse cleanly.
- [x] Lint check: no new lines >100 chars in the diff.
- [ ] After merge, trigger the three scheduled workflows and confirm they exit green with a soft-fail annotation in the step summary while IMDb is still blocking.