### PR TITLE
Auto-issue workflows: update existing issue instead of creating duplicates

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -73,10 +73,30 @@ jobs:
           name: lychee-report
           path: lychee-report.md
 
+      - name: Find existing open broken-links issue
+        id: find_issue
+        if: ${{ steps.lychee.outputs.exit_code != '0' && github.event_name != 'pull_request' && hashFiles('lychee-report.md') != '' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          existing=$(gh issue list \
+            --state open \
+            --label broken-links --label automated \
+            --json number,title \
+            --jq '.[] | select(.title=="Broken links detected") | .number' \
+            | head -1)
+          echo "number=${existing}" >> "$GITHUB_OUTPUT"
+          if [ -n "$existing" ]; then
+            echo "Updating existing issue #${existing}"
+          else
+            echo "No open issue found; will open a new one"
+          fi
+
       - name: Open or update issue on broken links
         if: ${{ steps.lychee.outputs.exit_code != '0' && github.event_name != 'pull_request' && hashFiles('lychee-report.md') != '' }}
         uses: peter-evans/create-issue-from-file@v5
         with:
+          issue-number: ${{ steps.find_issue.outputs.number }}
           title: "Broken links detected"
           content-filepath: ./lychee-report.md
           labels: |

--- a/.github/workflows/pa11y.yml
+++ b/.github/workflows/pa11y.yml
@@ -95,10 +95,30 @@ jobs:
             pa11y-report.json
             pa11y-report.md
 
+      - name: Find existing open a11y issue
+        id: find_issue
+        if: ${{ steps.audit.outputs.exit_code != '0' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          existing=$(gh issue list \
+            --state open \
+            --label accessibility --label automated \
+            --json number,title \
+            --jq '.[] | select(.title=="Accessibility issues detected (pa11y-ci)") | .number' \
+            | head -1)
+          echo "number=${existing}" >> "$GITHUB_OUTPUT"
+          if [ -n "$existing" ]; then
+            echo "Updating existing issue #${existing}"
+          else
+            echo "No open issue found; will open a new one"
+          fi
+
       - name: Open or update issue on a11y errors
         if: ${{ steps.audit.outputs.exit_code != '0' }}
         uses: peter-evans/create-issue-from-file@v5
         with:
+          issue-number: ${{ steps.find_issue.outputs.number }}
           title: "Accessibility issues detected (pa11y-ci)"
           content-filepath: ./pa11y-report.md
           labels: |

--- a/.github/workflows/repo-size.yml
+++ b/.github/workflows/repo-size.yml
@@ -96,10 +96,30 @@ jobs:
           mode: upsert
           create-if-not-exists: true
 
+      - name: Find existing open repo-size issue
+        id: find_issue
+        if: ${{ github.event_name == 'schedule' && steps.report.outputs.exceeded == 'true' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          existing=$(gh issue list \
+            --state open \
+            --label repo-health --label automated \
+            --json number,title \
+            --jq '.[] | select(.title=="Repo size exceeded threshold") | .number' \
+            | head -1)
+          echo "number=${existing}" >> "$GITHUB_OUTPUT"
+          if [ -n "$existing" ]; then
+            echo "Updating existing issue #${existing}"
+          else
+            echo "No open issue found; will open a new one"
+          fi
+
       - name: Open issue if scheduled run exceeded threshold
         if: ${{ github.event_name == 'schedule' && steps.report.outputs.exceeded == 'true' }}
         uses: peter-evans/create-issue-from-file@v5
         with:
+          issue-number: ${{ steps.find_issue.outputs.number }}
           title: "Repo size exceeded threshold"
           content-filepath: ./size-report.md
           labels: |


### PR DESCRIPTION
## Why

#59 and #68 are duplicates of each other — both are pa11y-ci accessibility audit reports with the same title (`Accessibility issues detected (pa11y-ci)`) and labels. The scheduled run on May 26 filed #59, and the manual `workflow_dispatch` ~14h later filed #68. They cover the exact same pages with effectively identical findings.

Root cause: `peter-evans/create-issue-from-file@v5` only updates an existing issue when you pass an explicit `issue-number` input. Without it, every run files a fresh issue, no matter the title. Despite the workflow steps being named "Open or update issue ...", the "or update" half wasn't actually wired up.

## What

Before each call to `peter-evans/create-issue-from-file`, add a small lookup step that queries `gh issue list` for an open issue with the canonical title + labels, and pipes its number into `issue-number`. When the lookup returns nothing (no open tracker), `issue-number` is empty and the action falls back to its existing "create a new issue" behavior.

Applied identically to the three workflows that share this pattern:

| Workflow | Title | Labels |
|---|---|---|
| `pa11y.yml` | `Accessibility issues detected (pa11y-ci)` | `accessibility`, `automated` |
| `link-check.yml` | `Broken links detected` | `broken-links`, `automated` |
| `repo-size.yml` | `Repo size exceeded threshold` | `repo-health`, `automated` |

All three already grant `issues: write`, which implicitly allows the read.

## Effect on existing trackers

- #59 (pa11y) — kept as the canonical accessibility tracker; the next pa11y run will edit it in place rather than file #71.
- #68 (pa11y) — closed as a duplicate of #59 before opening this PR.
- No open broken-links or repo-size issues right now; first time those workflows fire after this merges they'll behave the same as before. On subsequent runs they'll update in place instead of duplicating.

## Test plan

- [x] YAML parses for all three workflow files.
- [x] No new permissions required (all three already have `issues: write`).
- [ ] After merge, manually dispatch `pa11y.yml`. Verify it edits #59 instead of opening a new issue.