### PR TITLE
Top 1000: tolerate Rank arriving as integer or character

### DIFF
--- a/web_scraping/top1000_box_office.R
+++ b/web_scraping/top1000_box_office.R
@@ -115,7 +115,7 @@ for (url_index in all_urls) {
     rvest::html_node("table") %>%
     rvest::html_table(fill=TRUE) %>%
     tibble::as_tibble() %>%
-    dplyr::mutate(Rank = readr::parse_number(Rank))
+    dplyr::mutate(Rank = readr::parse_number(as.character(Rank)))
 
   # funny enough, before doing this, I just read in a list of imdb movies titles
   # and got the imdb id that way. but apparently multiple versions of beauty and the beast


### PR DESCRIPTION
## Why

After [#70](https://github.com/cavandonohoe/cavandonohoe.github.io/pull/70) made the IMDb scrapers soft-fail on anti-bot blocks, the IMDb-side errors stopped being the *first* failure in `update_top1000_box_office`. That exposed an unrelated, pre-existing bug: Box Office Mojo's chart table serves the `Rank` column with **mixed types** depending on the page:

| Page (offset) | Ranks shown | `Rank` column class |
|---|---|---|
| 0 | 1–200 | `<int>` |
| 200 | 201–400 | `<int>` |
| 400 | 401–600 | `<int>` |
| 600 | 601–800 | `<int>` |
| 800 | 801–1000 | `<chr>` (because rank 1000 renders as `"1,000"`) |

The previous code piped `Rank` directly into `readr::parse_number(Rank)`, which requires a character input and crashes with `is.character(x) is not TRUE` on the integer pages. The script worked previously because Box Office Mojo used to serve all pages as character (when ranks were small enough not to need a thousands separator anywhere, or when their HTML was wrapped differently).

This is why `data/top1000_box_office.csv` is ~5 months stale: every scheduled run since January has been crashing on this line.

## What

One-character fix:

```r
- dplyr::mutate(Rank = readr::parse_number(Rank))
+ dplyr::mutate(Rank = readr::parse_number(as.character(Rank)))
```

`as.character()` is a no-op on character input and a coercion on integer input, so the same code now works for both page shapes.

## Verification

Probed all 5 paginated pages live and confirmed:

- 200 rows per page, 1000 rows total
- Ranks parse contiguously to numeric `1..1000`
- No `NA`s in `Rank` after parsing
- Existing `is.na(Rank) & row_number() == 1000` fixup at line 141 is now dead code but harmless

Stepped through the script up to the rating loop locally — the `rankings_tib_final` tibble comes out structurally identical to the historical CSV (1000 rows, same column types).

## Note on the IMDb rating loop

This PR fixes the box-office table parse only. The downstream `get_rating()` calls hit `https://www.imdb.com/title/...` and may still soft-fail under the IMDb anti-bot block (HTTP 202 with empty body) until that lifts. After #70 merges, the existing `tryCatch(error = function(err) NA_real_)` in `get_rating()` will need a small follow-up to handle the typed `imdb_blocked` condition — I'll address that on #70's branch.