### PR TITLE
Fix accessibility findings across the site

### DIFF
--- a/.github/workflows/pr-smoke.yml
+++ b/.github/workflows/pr-smoke.yml
@@ -94,6 +94,8 @@ jobs:
                 try(googlesheets4::gs4_deauth(), silent = TRUE)
               }
               rmarkdown::render('$f', output_dir = '_smoke', encoding = 'UTF-8',
+                                output_options = list(self_contained = FALSE,
+                                                      lib_dir = '_smoke/site_libs'),
                                 envir = new.env(parent = globalenv()))
             "
             echo "::endgroup::"

--- a/about.Rmd
+++ b/about.Rmd
@@ -7,6 +7,7 @@ output:
       after_body: include_footer.html
 editor_options: 
   chunk_output_type: console
+lang: "en"
 ---
 
 
@@ -70,9 +71,16 @@ Now the thought is how to fully take advantage of the work from wherever lifesty
 I ended up working abroad! I worked from Spain, Italy, France, and Croatia! And I was actually responsibly productive about it. Cannot believe I did this in my 20s! Now what is next? Maybe an inspiring LinkedIn post... 
 
 
-```{r echo=FALSE}
-knitr::include_url("https://www.linkedin.com/embed/feed/update/urn:li:share:6956906897379590144", height = 570)
-
+```{=html}
+<iframe
+  src="https://www.linkedin.com/embed/feed/update/urn:li:share:6956906897379590144"
+  title="LinkedIn post: working abroad in 2022"
+  height="570"
+  width="100%"
+  style="border:0;"
+  loading="lazy"
+  data-external="1">
+</iframe>
 ```
 
 

--- a/avca_all_americans.Rmd
+++ b/avca_all_americans.Rmd
@@ -7,6 +7,7 @@ output:
     includes:
       in_header: header/header.html
       after_body: include_footer.html
+lang: "en"
 ---
 
 ```{r og-meta, echo=FALSE, results='asis'}

--- a/basic_operations_r.Rmd
+++ b/basic_operations_r.Rmd
@@ -8,6 +8,7 @@ output:
     includes:
       in_header: header/header.html
       after_body: include_footer.html
+lang: "en"
 ---
 
 # Basic Operations in R

--- a/best_pic_vs_top_1000.Rmd
+++ b/best_pic_vs_top_1000.Rmd
@@ -7,6 +7,7 @@ output:
     includes:
       in_header: header/header.html
       after_body: include_footer.html
+lang: "en"
 ---
 
 ```{r pipe, include=FALSE}

--- a/best_picture_nominees.Rmd
+++ b/best_picture_nominees.Rmd
@@ -7,6 +7,7 @@ output:
     includes:
       in_header: header/header.html
       after_body: include_footer.html
+lang: "en"
 ---
 
 ```{r og-meta, echo=FALSE, results='asis'}

--- a/confederate_statues.Rmd
+++ b/confederate_statues.Rmd
@@ -7,6 +7,7 @@ output:
     includes:
       in_header: header/header.html
       after_body: include_footer.html
+lang: "en"
 ---
 
 ```{r og-meta, echo=FALSE, results='asis'}

--- a/covid_cases_nostalgia.Rmd
+++ b/covid_cases_nostalgia.Rmd
@@ -12,6 +12,7 @@ output:
     includes:
       in_header: header/header.html
       after_body: include_footer.html
+lang: "en"
 ---
 
 ```{r og-meta, echo=FALSE, results='asis'}

--- a/cv.Rmd
+++ b/cv.Rmd
@@ -11,6 +11,7 @@ output:
 knit: pagedown::chrome_print
 editor_options: 
   chunk_output_type: console
+lang: "en"
 ---
 ```{r ci-skip-gs4_cv, include=FALSE}
 # if (Sys.getenv("CI") == "true") knitr::knit_exit()

--- a/cv_doc.Rmd
+++ b/cv_doc.Rmd
@@ -5,6 +5,7 @@ output:
     reference_docx: "format_resume_test2.dotx"
 editor_options: 
   chunk_output_type: console
+lang: "en"
 ---
 
 ```{r pipe_cv_doc, include=FALSE}

--- a/data_manipulation_r.Rmd
+++ b/data_manipulation_r.Rmd
@@ -8,6 +8,7 @@ output:
     includes:
       in_header: header/header.html
       after_body: include_footer.html
+lang: "en"
 ---
 
 # Data Manipulation in R

--- a/data_visualization_r.Rmd
+++ b/data_visualization_r.Rmd
@@ -8,6 +8,7 @@ output:
     includes:
       in_header: header/header.html
       after_body: include_footer.html
+lang: "en"
 ---
 
 # Data Visualization in R

--- a/firefighter_schedule.Rmd
+++ b/firefighter_schedule.Rmd
@@ -7,6 +7,7 @@ output:
     includes:
       in_header: header/header.html
       after_body: include_footer.html
+lang: "en"
 ---
 
 ```{r og-meta, echo=FALSE, results='asis'}

--- a/google_maps_saved_places.Rmd
+++ b/google_maps_saved_places.Rmd
@@ -7,6 +7,7 @@ output:
     includes:
       in_header: header/header.html
       after_body: include_footer.html
+lang: "en"
 ---
 
 ```{r og-meta, echo=FALSE, results='asis'}
@@ -29,6 +30,7 @@ This page embeds my Google My Maps layer and shows the latest exported CSV data 
 ```{=html}
 <iframe
   src="https://www.google.com/maps/d/embed?mid=1aSjDN50VR8qKu40GyIE2UsF6C8WzhGU&ehbc=2E312F"
+  title="Google Maps: Cavan's saved and favorite places"
   width="100%"
   height="650"
   style="border:0;"

--- a/imdb_rating_plot.Rmd
+++ b/imdb_rating_plot.Rmd
@@ -12,6 +12,7 @@ output:
     toc_float:
       collapsed: true
       smooth_scroll: true
+lang: "en"
 ---
 
 ```{r pipe, include=FALSE}

--- a/imdb_top_250_tv_series.Rmd
+++ b/imdb_top_250_tv_series.Rmd
@@ -7,6 +7,7 @@ output:
     includes:
       in_header: header/header.html
       after_body: include_footer.html
+lang: "en"
 ---
 
 ```{r og-meta, echo=FALSE, results='asis'}

--- a/include_footer.html
+++ b/include_footer.html
@@ -14,6 +14,88 @@
 </footer>
 <script>
 (function() {
+  function addLabel(el, label) {
+    if (!el) return;
+    if (el.hasAttribute('aria-label') && el.getAttribute('aria-label').trim()) return;
+    if (el.hasAttribute('title') && el.getAttribute('title').trim()) return;
+    el.setAttribute('aria-label', label);
+  }
+
+  function labelNavbarToggle() {
+    var toggles = document.querySelectorAll('button.navbar-toggle');
+    for (var i = 0; i < toggles.length; i++) {
+      addLabel(toggles[i], 'Toggle navigation');
+    }
+  }
+
+  function labelPlotlyModebar() {
+    var anchors = document.querySelectorAll('.modebar-container a, [id^="modebar-"] a');
+    for (var i = 0; i < anchors.length; i++) {
+      var a = anchors[i];
+      if ((a.hasAttribute('aria-label') && a.getAttribute('aria-label').trim()) ||
+          (a.hasAttribute('title') && a.getAttribute('title').trim())) continue;
+      var dataTitle = a.getAttribute('data-title') || '';
+      var label = dataTitle.trim() || 'Plot toolbar action';
+      a.setAttribute('aria-label', label);
+    }
+  }
+
+  function labelDataTablesControls() {
+    var inputs = document.querySelectorAll(
+      '.dataTables_wrapper input[type="search"], .dataTables_wrapper input[type="text"], ' +
+      'table.dataTable thead input[type="search"], table.dataTable thead input[type="text"]'
+    );
+    for (var i = 0; i < inputs.length; i++) {
+      var input = inputs[i];
+      if ((input.hasAttribute('aria-label') && input.getAttribute('aria-label').trim()) ||
+          (input.hasAttribute('title') && input.getAttribute('title').trim())) continue;
+      var placeholder = input.getAttribute('placeholder') || '';
+      var label = placeholder.trim() || 'Search';
+      var th = input.closest('th, td');
+      var col = th ? (th.getAttribute('aria-label') || th.textContent || '').trim() : '';
+      if (col) label = col + ' search';
+      input.setAttribute('aria-label', label);
+    }
+
+    var selects = document.querySelectorAll(
+      '.dataTables_wrapper select, table.dataTable thead select'
+    );
+    for (var j = 0; j < selects.length; j++) {
+      var sel = selects[j];
+      if ((sel.hasAttribute('aria-label') && sel.getAttribute('aria-label').trim()) ||
+          (sel.hasAttribute('title') && sel.getAttribute('title').trim())) continue;
+      var th2 = sel.closest('th, td');
+      var col2 = th2 ? (th2.getAttribute('aria-label') || th2.textContent || '').trim() : '';
+      sel.setAttribute('aria-label', col2 ? col2 + ' filter' : 'Column filter');
+    }
+  }
+
+  function applyA11yShims() {
+    labelNavbarToggle();
+    labelPlotlyModebar();
+    labelDataTablesControls();
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', applyA11yShims);
+  } else {
+    applyA11yShims();
+  }
+
+  // Plotly and DataTables can re-render after initial load; reapply on a short
+  // delay and observe further DOM changes so dynamically-inserted controls
+  // also get labelled before the pa11y wait window expires.
+  setTimeout(applyA11yShims, 250);
+  setTimeout(applyA11yShims, 1000);
+
+  if (typeof MutationObserver !== 'undefined') {
+    var observer = new MutationObserver(function() { applyA11yShims(); });
+    observer.observe(document.body, { childList: true, subtree: true });
+  }
+})();
+</script>
+<script>
+(function() {
   var btn = document.createElement('button');
   btn.className = 'dark-mode-toggle';
   btn.setAttribute('aria-label', 'Toggle dark mode');

--- a/index.Rmd
+++ b/index.Rmd
@@ -5,6 +5,7 @@ output:
     includes:
       in_header: header/header.html
       after_body: include_footer.html
+lang: "en"
 ---
 
 ```{r structured-data, echo=FALSE, results='asis'}

--- a/intro_to_r.Rmd
+++ b/intro_to_r.Rmd
@@ -8,6 +8,7 @@ output:
     includes:
       in_header: header/header.html
       after_body: include_footer.html
+lang: "en"
 ---
 
 # Introduction to R

--- a/la_real_estate.Rmd
+++ b/la_real_estate.Rmd
@@ -7,6 +7,7 @@ output:
     includes:
       in_header: header/header.html
       after_body: include_footer.html
+lang: "en"
 ---
 
 ```{r og-meta, echo=FALSE, results='asis'}

--- a/learn_r.Rmd
+++ b/learn_r.Rmd
@@ -8,6 +8,7 @@ output:
     includes:
       in_header: header/header.html
       after_body: include_footer.html
+lang: "en"
 ---
 
 Welcome to the "R Time Is Limited, Let's Make the Most of It" class! In this course, you will learn the basics of R programming and data analysis. R is a powerful and versatile programming language for statistical analysis, data visualization, and more.

--- a/my_imdb.Rmd
+++ b/my_imdb.Rmd
@@ -7,6 +7,7 @@ output:
     includes:
       in_header: header/header.html
       after_body: include_footer.html
+lang: "en"
 ---
 
 ```{r og-meta, echo=FALSE, results='asis'}

--- a/my_travels.Rmd
+++ b/my_travels.Rmd
@@ -13,6 +13,7 @@ output:
       smooth_scroll: true
 editor_options: 
   chunk_output_type: console
+lang: "en"
 ---
 
 Please note, I have pictures on my Instagram so I won't have any pictures on this blog. Give me a follow 😊

--- a/services.Rmd
+++ b/services.Rmd
@@ -5,6 +5,7 @@ output:
     includes:
       in_header: header/header.html
       after_body: include_footer.html
+lang: "en"
 ---
 
 If you have read the [*About Me*](https://cavandonohoe.github.io/about.html) section, you know of my passion for Data Science and making people's work easier. I have realized some older systems need improving. Sometimes Microsoft Excel (even when you have formulas), can bog down the run time given all the lingering manual work.

--- a/sierpinski_triangle.Rmd
+++ b/sierpinski_triangle.Rmd
@@ -7,6 +7,7 @@ output:
     includes:
       in_header: header/header.html
       after_body: include_footer.html
+lang: "en"
 ---
 
 ```{r pipe, include=FALSE}

--- a/sp500.Rmd
+++ b/sp500.Rmd
@@ -7,6 +7,7 @@ output:
     includes:
       in_header: header/header.html
       after_body: include_footer.html
+lang: "en"
 ---
 
 ```{r og-meta, echo=FALSE, results='asis'}

--- a/statistics_with_r.Rmd
+++ b/statistics_with_r.Rmd
@@ -8,6 +8,7 @@ output:
     includes:
       in_header: header/header.html
       after_body: include_footer.html
+lang: "en"
 ---
 
 # Statistics with R

--- a/tohs_reunion.Rmd
+++ b/tohs_reunion.Rmd
@@ -7,6 +7,7 @@ output:
     includes:
       in_header: header/header.html
       after_body: include_footer.html
+lang: "en"
 ---
 
 ```{r pipe, include=FALSE}

--- a/top_250_imdb_with_rt.Rmd
+++ b/top_250_imdb_with_rt.Rmd
@@ -7,6 +7,7 @@ output:
     includes:
       in_header: header/header.html
       after_body: include_footer.html
+lang: "en"
 ---
 
 ```{r og-meta, echo=FALSE, results='asis'}

--- a/us_rental_markets.Rmd
+++ b/us_rental_markets.Rmd
@@ -7,6 +7,7 @@ output:
     includes:
       in_header: header/header.html
       after_body: include_footer.html
+lang: "en"
 ---
 
 ```{r og-meta, echo=FALSE, results='asis'}


### PR DESCRIPTION
## Summary

Addresses every recurring finding in #59 (the weekly pa11y-ci audit) with surgical, mostly-static fixes. Closes #59 once the next audit run confirms zero errors.

### Static fixes (in source markup)
- `lang: "en"` added to every `.Rmd` YAML header so both `html_document` and `pagedown::html_resume` emit `<html lang="en">`. This is the WCAG-correct path (set at first paint, picked up by every screen reader before any JS runs).
- LinkedIn iframe in `about.Rmd`: replaced `knitr::include_url()` (which has no way to add a `title`) with raw HTML and added `title="LinkedIn post: working abroad in 2022"`.
- Google Maps iframe in `google_maps_saved_places.Rmd`: added `title="Google Maps: Cavan's saved and favorite places"`.

### JS shim (in `include_footer.html`)
For things rmarkdown / Bootstrap 3 / Plotly / DataTables generate that we can't easily configure at the R level, added a small idempotent shim that:

- labels the Bootstrap navbar-toggle button (`aria-label="Toggle navigation"`)
- labels plotly modebar anchors using their existing `data-title`, with a generic fallback
- labels DataTables per-column search inputs and length/filter selects, deriving the label from the surrounding `<th>` text when possible

The shim runs on DOMContentLoaded, again at 250ms and 1000ms, and stays subscribed to a `MutationObserver` on `document.body`, so widgets that render asynchronously still get labelled before pa11y-ci's 1500ms wait window expires.

## Why this split

Doing every fix as a JS shim would technically pass pa11y, but `<html lang>` and iframe titles deserve to be present at first paint for real screen-reader users — those went into the static markup. Plotly/DataTables internals are runtime-generated DOM that we can't touch from R, so a shim is the only practical option there.

## Test plan

- [ ] CI: pages-rmarkdown build succeeds (no Rmd renders broken by YAML edits).
- [ ] CI: weekly pa11y-ci run reports 0 errors across the 10 audited URLs (or, run the workflow manually after merge to confirm immediately).
- [ ] Spot-check rendered `_site/index.html` and `_site/about.html`: `<html lang="en">` present, navbar toggle has `aria-label="Toggle navigation"` after page load, modebar/DataTables controls labelled after page load.

CS-N/A (personal site, no Jira ticket).