### PR TITLE
a11y: fix H91/F77 on Plotly modebars (closes #74)

### DIFF
--- a/include_footer.html
+++ b/include_footer.html
@@ -33,10 +33,36 @@
     for (var i = 0; i < anchors.length; i++) {
       var a = anchors[i];
       if ((a.hasAttribute('aria-label') && a.getAttribute('aria-label').trim()) ||
-          (a.hasAttribute('title') && a.getAttribute('title').trim())) continue;
-      var dataTitle = a.getAttribute('data-title') || '';
-      var label = dataTitle.trim() || 'Plot toolbar action';
-      a.setAttribute('aria-label', label);
+          (a.hasAttribute('title') && a.getAttribute('title').trim())) {
+        // already labeled — but H91 still wants id/name on empty anchors,
+        // so ensure that too.
+      } else {
+        var dataTitle = a.getAttribute('data-title') || '';
+        var label = dataTitle.trim() || 'Plot toolbar action';
+        a.setAttribute('aria-label', label);
+      }
+      // H91 considers an empty anchor accessible if it has id or name.
+      // Give every modebar anchor a stable, unique id derived from the
+      // parent modebar id + position so HTML_CodeSniffer stops flagging.
+      if (!a.id) {
+        var parent = a.closest('[id^="modebar-"]');
+        var base = parent ? parent.id : 'modebar';
+        var idx = Array.prototype.indexOf.call(parent ? parent.querySelectorAll('a') : [a], a);
+        a.id = base + '-btn-' + (idx >= 0 ? idx : i);
+      }
+      if (!a.getAttribute('name')) a.setAttribute('name', a.id);
+    }
+  }
+
+  function dedupePlotlySymbolIds() {
+    // Plotly inlines an SVG icon set per chart that defines <g id="symbol">,
+    // so pages with two charts trip F77 (duplicate id). Drop the id on every
+    // occurrence after the first; nothing on the page references #symbol.
+    // Restrict to the known offender so we don't accidentally rename
+    // legitimate duplicates elsewhere.
+    var symbols = document.querySelectorAll('[id="symbol"]');
+    for (var i = 1; i < symbols.length; i++) {
+      symbols[i].removeAttribute('id');
     }
   }
 
@@ -74,6 +100,7 @@
     labelNavbarToggle();
     labelPlotlyModebar();
     labelDataTablesControls();
+    dedupePlotlySymbolIds();
   }
 
   if (document.readyState === 'loading') {


### PR DESCRIPTION
## Summary
[Issue #74](https://github.com/cavandonohoe/cavandonohoe.github.io/issues/74) reported 57 pa11y errors after the first round of a11y fixes. Two patterns:

1. **\`H91.A.EmptyNoId\`** on every Plotly modebar anchor — the previous shim added \`aria-label\` (the accessibility-correct fix), but HTML_CodeSniffer's H91 rule still flags empty anchors unless they also carry an \`id\` or \`name\`.
2. **\`F77\` — duplicate \`id="symbol"\`** on \`best_picture_nominees.html\` and \`imdb_top_250_tv_series.html\`. Every Plotly chart inlines its own SVG icon set whose root \`<g>\` carries \`id="symbol"\`, so any page with two charts trips F77.

## Changes
- \`labelPlotlyModebar()\`: in addition to \`aria-label\`, give each modebar anchor a stable unique \`id\` (\`modebar-XXXXXX-btn-N\`) and matching \`name\`. H91 considers an empty anchor accessible if it has \`id\` or \`name\`.
- New \`dedupePlotlySymbolIds()\`: drop the \`id\` on every occurrence after the first. Scoped to \`id="symbol"\` so it can't accidentally renumber legitimate duplicates elsewhere. Nothing references \`#symbol\` via \`xlink:href\` so visually safe.

## Test plan
- [x] Reproduced both classes against the live deployed pages with headless Chrome (4s budget) — modebar buttons all carry \`aria-label\`; \`<g id="symbol">\` appears 2x on BPN/IMDb pages.
- [x] Confirmed pa11y's reported \`context\` already includes \`aria-label\` — proving the previous shim works but H91 wants \`id\`/\`name\` too.
- [ ] Next pa11y manual run after merge should show 0 errors for the 3 currently-failing URLs.