### PR TITLE
Top 1000: persist IMDb ratings cache, batch fetches, surface progress

### DIFF
--- a/.github/workflows/update_top1000_box_office.yml
+++ b/.github/workflows/update_top1000_box_office.yml
@@ -40,14 +40,21 @@ jobs:
             any::lubridate
 
       - name: Refresh Best Picture + Top 1000 box office
+        env:
+          # Bound new IMDb fetches per run so the job always finishes
+          # under the 60-min job timeout even when IMDb is slow.
+          # Steady state (~few new entries / month) finishes well under
+          # this; cold-cache catches up over a couple of monthly runs.
+          MAX_NEW_RATINGS: "500"
         run: Rscript scripts/refresh_top1000_box_office.R
 
       - name: Verify only expected files changed
+        if: always()
         run: |
           set -euo pipefail
           unexpected="$(git diff --name-only HEAD \
             | grep -Ev '^data/(best_picture_winners|top1000_box_office)\.csv$' \
-            | grep -Ev '^data/best_picture_box_office_cache\.rds$' || true)"
+            | grep -Ev '^data/(best_picture_box_office_cache|top1000_imdb_ratings_cache)\.rds$' || true)"
           if [ -n "$unexpected" ]; then
             echo "ERROR: refresh modified unexpected files:"
             echo "$unexpected"
@@ -55,16 +62,48 @@ jobs:
           fi
 
       - name: Commit and push if changed
+        if: always()
         run: |
           set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add data/best_picture_winners.csv data/top1000_box_office.csv data/best_picture_box_office_cache.rds 2>/dev/null || true
+          # Stage CSVs + caches. Cache files preserve incremental progress
+          # across runs; without them every run re-fetches all 1000 IMDb
+          # ratings from scratch.
+          git add \
+            data/best_picture_winners.csv \
+            data/top1000_box_office.csv \
+            data/best_picture_box_office_cache.rds \
+            data/top1000_imdb_ratings_cache.rds \
+            2>/dev/null || true
           if git diff --cached --quiet; then
             echo "No changes."
             exit 0
           fi
-          git commit -m "Auto-update Top 1000 box office + Best Picture data"
+
+          # Build a useful commit message: which files changed, and how
+          # many cache entries the ratings cache picked up vs. previous.
+          changed_files="$(git diff --cached --name-only | tr '\n' ' ')"
+          cache_summary=""
+          if git diff --cached --name-only | grep -q top1000_imdb_ratings_cache.rds; then
+            new_n="$(Rscript -e 'cat(nrow(readRDS("data/top1000_imdb_ratings_cache.rds")))' 2>/dev/null || echo "?")"
+            old_n=0
+            if git show HEAD:data/top1000_imdb_ratings_cache.rds > /tmp/prev_cache.rds 2>/dev/null; then
+              old_n="$(Rscript -e 'cat(nrow(readRDS("/tmp/prev_cache.rds")))' 2>/dev/null || echo "0")"
+            fi
+            cache_summary="Top 1000 IMDb ratings cache: ${old_n} -> ${new_n} entries."
+          fi
+          {
+            echo "Auto-update Top 1000 box office + Best Picture data"
+            echo
+            echo "Changed: ${changed_files}"
+            if [ -n "$cache_summary" ]; then
+              echo
+              echo "$cache_summary"
+            fi
+          } > /tmp/commit-msg.txt
+
+          git commit -F /tmp/commit-msg.txt
           for i in 1 2 3; do
             if git push; then exit 0; fi
             echo "Push failed; rebasing on remote and retrying ($i/3)..."

--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,6 @@ site_libs/
 *.nb.html
 web_scraping/cache/
 logs/
-data/top1000_imdb_ratings_cache.rds
 
 # If you ever switch to Quarto, these help:
 .quarto/

--- a/scripts/refresh_top1000_box_office.R
+++ b/scripts/refresh_top1000_box_office.R
@@ -65,11 +65,28 @@ bo_result <- run_or_softfail_on_imdb_block(
   )
 )
 if (!inherits(bo_result, "imdb_block_softfail")) {
-  readr::write_csv(
-    imdb_rank_ratings_clean,
-    here::here("data", "top1000_box_office.csv")
-  )
-  message("[CI] Top 1000 Box Office scrape complete.")
+  # If MAX_NEW_RATINGS capped the run, some IDs may still be NA in the
+  # produced data frame. Don't publish a degraded CSV in that case;
+  # the cache still gets committed so the next run picks up where we
+  # left off.
+  na_count <- sum(is.na(imdb_rank_ratings_clean$imdb_rating))
+  if (na_count > 0) {
+    message(sprintf(
+      paste0(
+        "[CI] %d / %d ratings still missing after this run; ",
+        "preserving existing CSV. Cache will be committed so the ",
+        "next run continues from here."
+      ),
+      na_count,
+      nrow(imdb_rank_ratings_clean)
+    ))
+  } else {
+    readr::write_csv(
+      imdb_rank_ratings_clean,
+      here::here("data", "top1000_box_office.csv")
+    )
+    message("[CI] Top 1000 Box Office scrape complete.")
+  }
 } else {
   message("[CI] Top 1000 Box Office scrape skipped (IMDb block); CSV unchanged.")
 }

--- a/web_scraping/top1000_box_office.R
+++ b/web_scraping/top1000_box_office.R
@@ -199,18 +199,73 @@ title_lookup <- setNames(rankings_tib_final2$Title, rankings_tib_final2$id)
 missing_ids <- setdiff(rankings_tib_final2$id, names(ratings_lookup))
 
 if (length(missing_ids) > 0) {
+  total_missing <- length(missing_ids)
+  message(sprintf(
+    "[CI] %d cached ratings, %d missing.",
+    length(ratings_lookup), total_missing
+  ))
+
+  # CI batch cap: bound how many new IMDb pages this run will fetch so the
+  # job always finishes well under the 60-min job timeout. Set
+  # MAX_NEW_RATINGS to control; the workflow sets a CI default. Locally
+  # the variable is unset, so all missing ratings are fetched.
+  max_new_env <- Sys.getenv("MAX_NEW_RATINGS", unset = "")
+  if (nzchar(max_new_env)) {
+    max_new <- suppressWarnings(as.integer(max_new_env))
+    if (is.na(max_new) || max_new <= 0) max_new <- total_missing
+  } else {
+    max_new <- total_missing
+  }
+  if (max_new < total_missing) {
+    message(sprintf(
+      "[CI] Capping this run at %d new ratings (set MAX_NEW_RATINGS to override).",
+      max_new
+    ))
+  }
+
+  step_summary_path <- Sys.getenv("GITHUB_STEP_SUMMARY", unset = "")
+  write_progress_summary <- function(done, target, total, started_at) {
+    if (!nzchar(step_summary_path)) return(invisible(NULL))
+    elapsed_s <- as.numeric(difftime(Sys.time(), started_at, units = "secs"))
+    rate <- if (done > 0) elapsed_s / done else NA_real_
+    eta_s <- if (!is.na(rate)) rate * (target - done) else NA_real_
+    fmt_dur <- function(s) {
+      if (is.na(s) || !is.finite(s)) return("--:--")
+      sprintf("%02d:%02d", as.integer(s) %/% 60, as.integer(s) %% 60)
+    }
+    pct <- if (target > 0) sprintf("%.1f%%", 100 * done / target) else "n/a"
+    lines <- c(
+      "## Top 1000 box office \u2014 IMDb rating fetch progress",
+      "",
+      sprintf("- **This run**: %d / %d  (%s)", done, target, pct),
+      sprintf("- **Total missing (this run + future)**: %d", total),
+      sprintf("- **Elapsed**: %s, **ETA**: %s", fmt_dur(elapsed_s), fmt_dur(eta_s)),
+      ""
+    )
+    writeLines(lines, con = step_summary_path)
+  }
+
+  fetch_target <- min(max_new, total_missing)
+  started_at <- Sys.time()
   recent_titles <- character()
-  for (i in seq_along(missing_ids)) {
+  fetched_this_run <- 0
+  for (i in seq_len(fetch_target)) {
     title_id <- missing_ids[[i]]
     title_name <- title_lookup[[title_id]]
     ratings_lookup[[title_id]] <- get_rating(title_id)
+    fetched_this_run <- i
     recent_titles <- c(recent_titles, sprintf("%s (%s)", title_name, title_id))
 
-    if (i %% 10 == 0 || i == length(missing_ids)) {
-      message(sprintf("Fetched %d/%d:", i, length(missing_ids)))
+    if (i %% 10 == 0 || i == fetch_target) {
+      pct <- 100 * i / fetch_target
+      message(sprintf(
+        "Fetched %d/%d (%.1f%%, missing total %d):",
+        i, fetch_target, pct, total_missing
+      ))
       message(paste(recent_titles, collapse = "\n"))
       message("")
       recent_titles <- character()
+      write_progress_summary(i, fetch_target, total_missing, started_at)
     }
 
     if (i %% 25 == 0) {
@@ -221,6 +276,7 @@ if (length(missing_ids) > 0) {
       )
     }
   }
+  write_progress_summary(fetched_this_run, fetch_target, total_missing, started_at)
 }
 
 saveRDS(


### PR DESCRIPTION
## Summary
The Top 1000 box office workflow takes ~30 min on a typical run because every CI invocation re-fetches all 1000 IMDb ratings from scratch. The ratings cache file (\`data/top1000_imdb_ratings_cache.rds\`) was explicitly gitignored, so even though the scraper saves it incrementally during the run, it was never committed and the next run started cold.

This PR addresses the timeout risk in three layers and adds visibility.

## Changes

### 1. Persist the IMDb ratings cache (the big one)
- Remove \`data/top1000_imdb_ratings_cache.rds\` from \`.gitignore\`.
- Workflow now stages and commits it alongside the CSVs.
- Steady-state runs hit a fully-warmed cache on the first iteration and only fetch the few entries that newly entered the box-office top 1000 since last month \u2192 typical runtime drops from ~30 min to a couple of minutes.

### 2. Batch cap (\`MAX_NEW_RATINGS\`)
- New env var bounds how many IMDb pages one run will fetch; workflow sets 500.
- If more remain, the script commits the partial cache and exits cleanly **without writing the public CSV** (so we never publish NA ratings).
- Next run continues from the persisted cache. Cold-start (after this merges, when the cache file doesn't exist yet) takes 2 monthly runs to fully populate.

### 3. Visibility
- Periodic \`GITHUB_STEP_SUMMARY\` writes show live progress on the run page: \`X / Y, percent, elapsed, ETA\`.
- Per-batch console log lines now include percent and total-missing count.
- Commit step uses \`if: always()\` so partial cache progress is committed **even if the scrape step times out or errors out partway through**. Previously, a timeout meant zero progress was preserved across runs.
- Commit message gains a \`Top 1000 IMDb ratings cache: M -> N entries\` line so you can see at a glance whether each run made progress.

## Test plan
- [x] Verified \`MAX_NEW_RATINGS\` parsing locally (unset \u2192 unlimited; positive int \u2192 cap; invalid \u2192 unlimited).
- [x] Linted: all lines \u2264 100 chars, no \`library()\`, all calls explicit-prefixed.
- [ ] First post-merge run: should fetch up to 500 IMDb pages, commit only the cache (CSV unchanged), and show a progress summary on the run page.
- [ ] Second monthly run: should finish in a few minutes with both CSV and cache updated, and the commit message should show \`cache: 500 -> 1000 entries\`.
- [ ] Subsequent monthly runs: should complete in well under 5 min in steady state.