### PR TITLE
lighthouse: real PR trigger + keep post-build audit

### DIFF
--- a/.github/lighthouserc.cjs
+++ b/.github/lighthouserc.cjs
@@ -1,22 +1,38 @@
+// Lighthouse CI config used by .github/workflows/lighthouse.yml.
+//
+// Two modes are supported, selected by the LHCI_BASE_URL env var:
+//
+//   1. Local serve (workflow_run after a successful build):
+//        LHCI_BASE_URL unset  -> defaults to http://localhost:4567
+//      The workflow downloads the `site` artifact, serves it with http-server,
+//      and Lighthouse audits the local copy.
+//
+//   2. Deployed preview (pull_request):
+//        LHCI_BASE_URL = https://cavandonohoe.github.io/pr-<n>
+//      The workflow waits for the preview to be live, then audits the real URL.
+//
+// The set of pages audited is identical in both modes.
+
+const baseUrl = process.env.LHCI_BASE_URL || "http://localhost:4567";
+
+const pages = [
+  "/index.html",
+  "/about.html",
+  "/cv.html",
+  "/best_picture_nominees.html",
+  "/sp500.html"
+];
+
 module.exports = {
   ci: {
     collect: {
-      // Pages are served statically; no startServerCommand needed because
-      // the workflow runs http-server in the background.
-      url: [
-        "http://localhost:4567/index.html",
-        "http://localhost:4567/about.html",
-        "http://localhost:4567/cv.html",
-        "http://localhost:4567/best_picture_nominees.html",
-        "http://localhost:4567/sp500.html"
-      ],
+      url: pages.map((p) => `${baseUrl}${p}`),
       numberOfRuns: 1,
       settings: {
         chromeFlags: "--no-sandbox --disable-dev-shm-usage --headless=new"
       }
     },
     assert: {
-      // Soft thresholds — warn, don't fail the build.
       assertions: {
         "categories:performance": ["warn", { "minScore": 0.7 }],
         "categories:accessibility": ["warn", { "minScore": 0.85 }],

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,6 +1,10 @@
 name: Lighthouse CI
 
 on:
+  # Audit every PR against its deployed preview URL.
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  # Audit production after each successful main build, using the build artifact.
   workflow_run:
     workflows: ["Build site + deploy prod & PR previews (branch-based Pages)"]
     types: [completed]
@@ -12,12 +16,101 @@ permissions:
   actions: read
 
 concurrency:
-  group: lighthouse-${{ github.event.workflow_run.head_branch || github.ref }}
+  group: lighthouse-${{ github.event.pull_request.number || github.event.workflow_run.head_branch || github.ref }}
   cancel-in-progress: true
 
 jobs:
-  lighthouse:
-    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
+  # ---------------------------------------------------------------------------
+  # Mode 1: pull_request -> audit deployed preview URL.
+  # Skips Dependabot PRs (no preview gets deployed for them).
+  # ---------------------------------------------------------------------------
+  lighthouse-preview:
+    name: Lighthouse (PR preview)
+    if: ${{ github.event_name == 'pull_request' && github.actor != 'dependabot[bot]' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "20"
+
+      - name: Install Lighthouse CI
+        run: npm install -g @lhci/cli@0.14.x
+
+      - name: Wait for PR preview to be live
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          base="https://cavandonohoe.github.io/pr-${PR_NUMBER}"
+          url="${base}/index.html"
+          echo "Waiting for ${url}..."
+          for i in $(seq 1 60); do
+            code="$(curl -s -o /dev/null -w '%{http_code}' "$url" || true)"
+            if [ "$code" = "200" ]; then
+              echo "Preview is live."
+              exit 0
+            fi
+            echo "Attempt ${i}/60: HTTP ${code}; sleeping 10s..."
+            sleep 10
+          done
+          echo "Preview never became live; aborting."
+          exit 1
+
+      - name: Run Lighthouse CI against preview
+        id: lhci
+        env:
+          LHCI_BASE_URL: https://cavandonohoe.github.io/pr-${{ github.event.pull_request.number }}
+        run: |
+          set +e
+          lhci autorun --config=.github/lighthouserc.cjs > lhci.log 2>&1
+          echo "exit_code=$?" >> "$GITHUB_OUTPUT"
+          tail -200 lhci.log
+          set -e
+
+      - name: Build PR comment
+        run: |
+          {
+            echo "## Lighthouse CI (PR preview)"
+            echo ""
+            echo "Audited: \`https://cavandonohoe.github.io/pr-${{ github.event.pull_request.number }}/\`"
+            echo ""
+            echo "\`\`\`"
+            grep -E "(http|Performance|Accessibility|Best Practices|SEO|Report:)" lhci.log | head -100 || true
+            echo "\`\`\`"
+          } > lhci-comment.md
+
+      - name: Comment on PR
+        uses: thollander/actions-comment-pull-request@v3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          pr-number: ${{ github.event.pull_request.number }}
+          file-path: ./lhci-comment.md
+          comment-tag: lighthouse-ci
+          mode: upsert
+          create-if-not-exists: true
+
+      - name: Upload Lighthouse logs
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: lighthouse-logs-pr-${{ github.event.pull_request.number }}
+          path: |
+            lhci.log
+            .lighthouseci/**
+          if-no-files-found: ignore
+
+  # ---------------------------------------------------------------------------
+  # Mode 2: workflow_run after a successful main build -> audit local artifact.
+  # Also handles workflow_dispatch (uses latest successful main build).
+  # ---------------------------------------------------------------------------
+  lighthouse-artifact:
+    name: Lighthouse (build artifact)
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main')
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -31,6 +124,8 @@ jobs:
           name: site
           path: _site
           if_no_artifact_found: warn
+          workflow: pages-branch-previews.yml
+          branch: main
 
       - name: Bail if no site artifact
         id: presence
@@ -58,9 +153,11 @@ jobs:
           echo $! > server.pid
           sleep 2
 
-      - name: Run Lighthouse CI
+      - name: Run Lighthouse CI against artifact
         if: steps.presence.outputs.have_site == 'true'
         id: lhci
+        env:
+          LHCI_BASE_URL: http://localhost:4567
         run: |
           set +e
           lhci autorun --config=.github/lighthouserc.cjs > lhci.log 2>&1
@@ -72,44 +169,11 @@ jobs:
         if: always()
         run: kill "$(cat server.pid)" 2>/dev/null || true
 
-      - name: Resolve PR number
-        if: steps.presence.outputs.have_site == 'true'
-        id: pr
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -e
-          n="$(gh pr list --state open --head '${{ github.event.workflow_run.head_branch }}' --json number --jq '.[0].number' || true)"
-          echo "number=${n}" >> "$GITHUB_OUTPUT"
-          echo "PR number: ${n:-none}"
-
-      - name: Build PR comment
-        if: ${{ steps.presence.outputs.have_site == 'true' && steps.pr.outputs.number != '' }}
-        run: |
-          {
-            echo "## Lighthouse CI"
-            echo ""
-            echo "\`\`\`"
-            grep -E "(http://localhost|Performance|Accessibility|Best Practices|SEO|Report:)" lhci.log | head -100 || true
-            echo "\`\`\`"
-          } > lhci-comment.md
-
-      - name: Comment on PR
-        if: ${{ steps.presence.outputs.have_site == 'true' && steps.pr.outputs.number != '' }}
-        uses: thollander/actions-comment-pull-request@v3
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          pr-number: ${{ steps.pr.outputs.number }}
-          file-path: ./lhci-comment.md
-          comment-tag: lighthouse-ci
-          mode: upsert
-          create-if-not-exists: true
-
       - name: Upload Lighthouse logs
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: lighthouse-logs
+          name: lighthouse-logs-${{ github.run_id }}
           path: |
             lhci.log
             .lighthouseci/**

--- a/README.Rmd
+++ b/README.Rmd
@@ -84,7 +84,9 @@ manual is a click away on the Actions tab.
 
 * `link-check.yml` -- weekly + on-PR broken-link check (lychee).
 * `pa11y.yml` -- weekly accessibility audit (pa11y-ci).
-* `lighthouse.yml` -- on-PR Lighthouse CI run with score comment.
+* `lighthouse.yml` -- two modes: on-PR audit of the deployed preview URL
+  with a score comment, plus a post-build audit of the production
+  artifact after each successful main build.
 * `repo-size.yml` -- weekly + on-PR repo-size report.
 
 ### Code quality

--- a/README.md
+++ b/README.md
@@ -90,7 +90,9 @@ manual is a click away on the Actions tab.
 
 - `link-check.yml` — weekly + on-PR broken-link check (lychee).
 - `pa11y.yml` — weekly accessibility audit (pa11y-ci).
-- `lighthouse.yml` — on-PR Lighthouse CI run with score comment.
+- `lighthouse.yml` — two modes: on-PR audit of the deployed preview
+  URL with a score comment, plus a post-build audit of the production
+  artifact after each successful main build.
 - `repo-size.yml` — weekly + on-PR repo-size report.
 
 ### Code quality


### PR DESCRIPTION
## Summary

The Lighthouse CI workflow was registered with two triggers (`workflow_run` after a successful build + `workflow_dispatch`) but had **never** fired automatically — the only run in history was a manual dispatch from May 26. So the README's promise of "on-PR Lighthouse CI run with score comment" wasn't being kept.

This PR restructures `lighthouse.yml` so it actually delivers what the README claims, **and** keeps a post-deploy audit for production builds.

## What changes

- **New `lighthouse-preview` job** triggers on `pull_request`. Waits for the PR's GitHub Pages preview URL (`https://cavandonohoe.github.io/pr-<n>/`) to become live, then runs Lighthouse CI directly against it. Posts/upserts a score comment on the PR. This is more honest than auditing a locally-served artifact since it measures the real CDN, real DNS, and real headers.
- **`lighthouse-artifact` job** keeps the existing `workflow_run` + `workflow_dispatch` flow (download build artifact, serve locally, audit). No PR comment in this mode — that's covered by the preview job.
- **`.github/lighthouserc.cjs`** now reads `LHCI_BASE_URL` from env, so the same config drives both jobs. Same five pages audited; same warn-only thresholds.
- **README** updated to honestly describe both modes.

## Test plan

- [ ] Confirm the `lighthouse-preview` job fires when this PR is opened/synchronized
- [ ] Confirm it waits for the preview to be live (the 60x10s loop) and then audits it
- [ ] Confirm the score comment shows up on this PR
- [ ] After merge, confirm `lighthouse-artifact` fires via `workflow_run` on the main build
- [ ] Confirm Dependabot PRs are skipped (no preview gets deployed)