### PR TITLE
Add Director's Box Office Trajectory page

### DIFF
--- a/.github/workflows/update_director_filmographies.yml
+++ b/.github/workflows/update_director_filmographies.yml
@@ -1,0 +1,80 @@
+name: Refresh director filmographies (TMDb)
+
+on:
+  workflow_dispatch:
+  schedule:
+    # 17th of each month, 14:07 UTC. Spaced away from other monthly
+    # data refreshes (top1000 on the 8th, top250 on the 12th).
+    - cron: "7 14 17 * *"
+
+permissions:
+  contents: write
+
+concurrency:
+  group: refresh-director-filmographies
+  cancel-in-progress: false
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          packages: |
+            any::dplyr
+            any::tibble
+            any::stringr
+            any::readr
+            any::here
+            any::httr2
+            any::jsonlite
+            any::purrr
+
+      - name: Refresh director filmographies
+        env:
+          TMDB_API_KEY: ${{ secrets.TMDB_API_KEY }}
+        run: Rscript scripts/refresh_director_filmographies.R
+
+      - name: Verify only expected files changed
+        if: always()
+        run: |
+          set -euo pipefail
+          unexpected="$(git diff --name-only HEAD \
+            | grep -Ev '^data/director_filmographies(_meta)?\.csv$' || true)"
+          if [ -n "$unexpected" ]; then
+            echo "ERROR: refresh modified unexpected files:"
+            echo "$unexpected"
+            exit 1
+          fi
+
+      - name: Commit and push if changed
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add data/director_filmographies.csv data/director_filmographies_meta.csv
+          if git diff --cached --quiet; then
+            echo "No changes."
+            exit 0
+          fi
+          n_films="$(wc -l < data/director_filmographies.csv | tr -d ' ')"
+          {
+            echo "Auto-update director filmographies"
+            echo
+            echo "Total film rows (incl. header): ${n_films}"
+          } > /tmp/commit-msg.txt
+          git commit -F /tmp/commit-msg.txt
+          for i in 1 2 3; do
+            if git push; then exit 0; fi
+            echo "Push failed; rebasing on remote and retrying ($i/3)..."
+            git pull --rebase origin "$(git rev-parse --abbrev-ref HEAD)"
+          done
+          echo "ERROR: failed to push director filmographies update after 3 attempts."
+          exit 1

--- a/README.Rmd
+++ b/README.Rmd
@@ -34,6 +34,7 @@ Movies & data:
 * [Top 250 Rated Movies with Rotten Tomato Scores](https://cavandonohoe.github.io/top_250_imdb_with_rt.html)
 * [IMDb Series Rating Plots](https://cavandonohoe.github.io/imdb_rating_plot.html)
 * [Best Picture Nominees](https://cavandonohoe.github.io/best_picture_nominees.html)
+* [Director Box Office Trajectory](https://cavandonohoe.github.io/director_box_office_trajectory.html)
 * [Rent vs. Buy Calculator](https://cavandonohoe.shinyapps.io/rent-vs-buy/) ([source](https://github.com/cavandonohoe/rent-vs-buy))
 * [Confederate Statue Analysis](https://github.com/cavandonohoe/confederate_statues)
 * [Sierpinski Triangle](https://cavandonohoe.github.io/sierpinski_triangle.html)
@@ -69,6 +70,8 @@ manual is a click away on the Actions tab.
   box office refresh.
 * `update_top250_with_rt.yml` -- monthly Top 250 + Rotten Tomatoes
   refresh.
+* `update_director_filmographies.yml` -- monthly TMDb director
+  filmography refresh for the Director Box Office Trajectory page.
 * `update_sp500.yml` -- weekly VOO price refresh.
 * `update_us_rentals.yml` -- monthly Zillow ZHVI/ZORI refresh.
 * `update_mymaps_export.yml` -- weekly Google My Maps export.

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Movies & data:
   Plots](https://cavandonohoe.github.io/imdb_rating_plot.html)
 - [Best Picture
   Nominees](https://cavandonohoe.github.io/best_picture_nominees.html)
+- [Director Box Office
+  Trajectory](https://cavandonohoe.github.io/director_box_office_trajectory.html)
 - [Rent vs. Buy
   Calculator](https://cavandonohoe.shinyapps.io/rent-vs-buy/)
   ([source](https://github.com/cavandonohoe/rent-vs-buy))
@@ -75,6 +77,8 @@ manual is a click away on the Actions tab.
   box office refresh.
 - `update_top250_with_rt.yml` — monthly Top 250 + Rotten Tomatoes
   refresh.
+- `update_director_filmographies.yml` — monthly TMDb director
+  filmography refresh for the Director Box Office Trajectory page.
 - `update_sp500.yml` — weekly VOO price refresh.
 - `update_us_rentals.yml` — monthly Zillow ZHVI/ZORI refresh.
 - `update_mymaps_export.yml` — weekly Google My Maps export.

--- a/_site.yml
+++ b/_site.yml
@@ -33,6 +33,8 @@ navbar:
         href: best_picture_nominees.html
       - text: "Best Picture and Top 1000 Box Office"
         href: best_pic_vs_top_1000.html
+      - text: "Director Box Office Trajectory"
+        href: director_box_office_trajectory.html
       - text: "My IMDb Ratings"
         href: my_imdb.html
       - text: "--- Sports & Personal ---"

--- a/director_box_office_trajectory.Rmd
+++ b/director_box_office_trajectory.Rmd
@@ -1,0 +1,329 @@
+---
+title: "Director's Box Office Trajectory"
+editor_options:
+  chunk_output_type: console
+output:
+  html_document:
+    includes:
+      in_header: header/header.html
+      after_body: include_footer.html
+    toc: true
+    toc_depth: 3
+    toc_float:
+      collapsed: true
+      smooth_scroll: true
+lang: "en"
+---
+
+```{r og-meta, echo=FALSE, results='asis'}
+cat('
+<meta property="og:title" content="Director Box Office Trajectory">
+<meta property="og:description" content="Career box office trajectories for the 10 highest-grossing film directors of all time, in nominal and inflation-adjusted USD.">
+<meta property="og:url" content="https://cavandonohoe.github.io/director_box_office_trajectory.html">
+<meta property="og:type" content="article">
+')
+```
+
+```{r pipe, include=FALSE}
+`%>%` <- magrittr::`%>%`
+```
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(
+  echo = FALSE, message = FALSE, warning = FALSE,
+  fig.width = 10, fig.height = 6, dpi = 110
+)
+```
+
+```{r data}
+films_path <- here::here("data", "director_filmographies.csv")
+meta_path <- here::here("data", "director_filmographies_meta.csv")
+
+data_available <- file.exists(films_path) && file.exists(meta_path)
+
+if (data_available) {
+  films <- readr::read_csv(films_path, show_col_types = FALSE)
+  meta <- readr::read_csv(meta_path, show_col_types = FALSE)
+
+  director_levels <- meta %>%
+    dplyr::arrange(.data$director_rank) %>%
+    dplyr::pull(.data$director_display_name)
+
+  films <- films %>%
+    dplyr::mutate(
+      director_display_name = factor(
+        .data$director_display_name,
+        levels = director_levels
+      )
+    )
+} else {
+  films <- tibble::tibble()
+  meta <- tibble::tibble()
+}
+```
+
+```{r data-placeholder, eval = !data_available, results = 'asis'}
+cat(
+  '<div class="alert alert-info" style="padding:1em;border:1px solid #b8daff;',
+  'background:#cce5ff;border-radius:4px;margin:1em 0;">',
+  '<strong>Data not yet available.</strong> This page is populated by ',
+  '<code>scripts/refresh_director_filmographies.R</code>, which runs ',
+  'monthly via the <code>update_director_filmographies.yml</code> ',
+  'GitHub Action. The action requires a <code>TMDB_API_KEY</code> ',
+  'repo secret. Once it has run, this page will fill in.',
+  '</div>\n'
+)
+```
+
+```{r timestamp, eval = data_available, results='asis'}
+cat(sprintf(
+  '<span class="data-timestamp">Data last updated: %s</span>\n',
+  format(as.Date(system(paste("git log -1 --format=%ai --",
+    here::here("data", "director_filmographies.csv")), intern = TRUE)), "%B %d, %Y")
+))
+```
+
+How does a director's box office change across their career? Here are the
+career trajectories of the **10 highest-grossing film directors of all time**
+(by cumulative worldwide box office, per
+[Wikipedia](https://en.wikipedia.org/wiki/List_of_highest-grossing_film_directors)),
+sourced from [TMDb](https://www.themoviedb.org/) and refreshed monthly.
+
+All dollar amounts are **worldwide** box office. The "inflation-adjusted"
+panels convert nominal USD to 2025-equivalent dollars using BLS CPI-U
+All Urban Consumers.
+
+## Leaderboard
+
+```{r leaderboard, eval = data_available}
+leaderboard <- meta %>%
+  dplyr::transmute(
+    Rank = .data$director_rank,
+    Director = .data$director_display_name,
+    Films = .data$n_films,
+    `Active years` = paste0(.data$first_year, "-", .data$last_year),
+    `Lifetime gross (nominal)` = scales::dollar(
+      .data$lifetime_revenue,
+      scale = 1e-9, suffix = "B", accuracy = 0.01
+    ),
+    `Lifetime gross (2025 USD)` = scales::dollar(
+      .data$lifetime_revenue_2025,
+      scale = 1e-9, suffix = "B", accuracy = 0.01
+    ),
+    `Avg per film (2025 USD)` = scales::dollar(
+      .data$avg_revenue_per_film_2025,
+      scale = 1e-6, suffix = "M", accuracy = 1
+    ),
+    `Avg TMDb vote` = round(.data$avg_vote, 2)
+  )
+
+DT::datatable(
+  leaderboard,
+  rownames = FALSE,
+  options = list(
+    pageLength = 10, dom = "tip",
+    columnDefs = list(list(className = "dt-right", targets = c(2, 4, 5, 6, 7)))
+  )
+)
+```
+
+## Trajectory by career film number {.tabset .tabset-pills}
+
+x-axis is **career film number** (their first directing credit on TMDb is 1,
+their second is 2, etc.). Each panel uses its own y-axis to make the shape
+of the trajectory visible regardless of scale.
+
+### Inflation-adjusted gross (2025 USD)
+
+```{r traj-real, eval = data_available}
+plot_films <- films %>%
+  dplyr::filter(.data$revenue_usable, !is.na(.data$revenue_2025))
+
+ggplot2::ggplot(
+  plot_films,
+  ggplot2::aes(x = .data$career_film_number, y = .data$revenue_2025 / 1e6)
+) +
+  ggplot2::geom_line(color = "grey40", alpha = 0.6) +
+  ggplot2::geom_point(
+    ggplot2::aes(size = .data$vote_average, color = .data$release_year),
+    alpha = 0.85
+  ) +
+  ggplot2::facet_wrap(
+    ~ .data$director_display_name,
+    scales = "free_y", ncol = 2
+  ) +
+  ggplot2::scale_color_viridis_c(option = "plasma", end = 0.9) +
+  ggplot2::scale_size_continuous(range = c(1.5, 5), limits = c(4, 9)) +
+  ggplot2::scale_y_continuous(
+    labels = scales::label_dollar(scale = 1, suffix = "M")
+  ) +
+  ggplot2::labs(
+    x = "Career film number",
+    y = "Worldwide gross (2025 USD, millions)",
+    color = "Release year",
+    size = "TMDb vote",
+    caption = "Data: TMDb. Inflation adjustment: BLS CPI-U."
+  ) +
+  ggplot2::theme_minimal(base_size = 11) +
+  ggplot2::theme(
+    panel.grid.minor = ggplot2::element_blank(),
+    legend.position = "bottom"
+  )
+```
+
+### Nominal gross
+
+```{r traj-nominal, eval = data_available}
+ggplot2::ggplot(
+  plot_films,
+  ggplot2::aes(x = .data$career_film_number, y = .data$revenue / 1e6)
+) +
+  ggplot2::geom_line(color = "grey40", alpha = 0.6) +
+  ggplot2::geom_point(
+    ggplot2::aes(size = .data$vote_average, color = .data$release_year),
+    alpha = 0.85
+  ) +
+  ggplot2::facet_wrap(
+    ~ .data$director_display_name,
+    scales = "free_y", ncol = 2
+  ) +
+  ggplot2::scale_color_viridis_c(option = "plasma", end = 0.9) +
+  ggplot2::scale_size_continuous(range = c(1.5, 5), limits = c(4, 9)) +
+  ggplot2::scale_y_continuous(
+    labels = scales::label_dollar(scale = 1, suffix = "M")
+  ) +
+  ggplot2::labs(
+    x = "Career film number",
+    y = "Worldwide gross (nominal USD, millions)",
+    color = "Release year",
+    size = "TMDb vote"
+  ) +
+  ggplot2::theme_minimal(base_size = 11) +
+  ggplot2::theme(
+    panel.grid.minor = ggplot2::element_blank(),
+    legend.position = "bottom"
+  )
+```
+
+### TMDb vote average
+
+Showing only films with at least 100 votes so we don't trust thin samples
+on early-career indie titles.
+
+```{r traj-vote, eval = data_available}
+vote_films <- films %>%
+  dplyr::filter(!is.na(.data$vote_average), .data$vote_count >= 100)
+
+ggplot2::ggplot(
+  vote_films,
+  ggplot2::aes(x = .data$career_film_number, y = .data$vote_average)
+) +
+  ggplot2::geom_line(color = "grey40", alpha = 0.6) +
+  ggplot2::geom_point(
+    ggplot2::aes(size = .data$vote_count, color = .data$release_year),
+    alpha = 0.85
+  ) +
+  ggplot2::facet_wrap(
+    ~ .data$director_display_name,
+    scales = "free_y", ncol = 2
+  ) +
+  ggplot2::scale_color_viridis_c(option = "plasma", end = 0.9) +
+  ggplot2::scale_size_continuous(range = c(1.5, 5)) +
+  ggplot2::labs(
+    x = "Career film number",
+    y = "TMDb vote average (1-10)",
+    color = "Release year",
+    size = "Votes",
+    caption = "Films with < 100 TMDb votes excluded."
+  ) +
+  ggplot2::theme_minimal(base_size = 11) +
+  ggplot2::theme(
+    panel.grid.minor = ggplot2::element_blank(),
+    legend.position = "bottom"
+  )
+```
+
+## Top 5 by director (2025 USD)
+
+```{r top-films, eval = data_available}
+top_films <- films %>%
+  dplyr::filter(.data$revenue_usable) %>%
+  dplyr::group_by(.data$director_display_name) %>%
+  dplyr::slice_max(order_by = .data$revenue_2025, n = 5) %>%
+  dplyr::arrange(.data$director_display_name, dplyr::desc(.data$revenue_2025)) %>%
+  dplyr::ungroup() %>%
+  dplyr::transmute(
+    Director = .data$director_display_name,
+    Title = .data$title,
+    Year = .data$release_year,
+    `Gross (nominal)` = scales::dollar(
+      .data$revenue, scale = 1e-6, suffix = "M", accuracy = 1
+    ),
+    `Gross (2025 USD)` = scales::dollar(
+      .data$revenue_2025, scale = 1e-6, suffix = "M", accuracy = 1
+    ),
+    `TMDb vote` = round(.data$vote_average, 1)
+  )
+
+DT::datatable(
+  top_films,
+  rownames = FALSE,
+  filter = "top",
+  options = list(pageLength = 10, dom = "ftip")
+)
+```
+
+## All films
+
+```{r all-films, eval = data_available}
+all_films_table <- films %>%
+  dplyr::transmute(
+    Director = .data$director_display_name,
+    `#` = .data$career_film_number,
+    Title = .data$title,
+    Year = .data$release_year,
+    `Runtime (min)` = .data$runtime,
+    `Budget (nominal)` = ifelse(
+      .data$budget_usable,
+      scales::dollar(.data$budget, scale = 1e-6, suffix = "M", accuracy = 1),
+      "—"
+    ),
+    `Gross (nominal)` = ifelse(
+      .data$revenue_usable,
+      scales::dollar(.data$revenue, scale = 1e-6, suffix = "M", accuracy = 1),
+      "—"
+    ),
+    `Gross (2025 USD)` = ifelse(
+      .data$revenue_usable,
+      scales::dollar(.data$revenue_2025, scale = 1e-6, suffix = "M", accuracy = 1),
+      "—"
+    ),
+    `TMDb vote` = round(.data$vote_average, 1),
+    Votes = .data$vote_count
+  )
+
+DT::datatable(
+  all_films_table,
+  rownames = FALSE,
+  filter = "top",
+  options = list(pageLength = 25, dom = "ftip")
+)
+```
+
+## Notes
+
+- Filmography data is pulled from
+  [TMDb](https://www.themoviedb.org/), filtering each director's movie
+  credits to those where `job == "Director"`.
+- The Russo brothers (Anthony & Joe) are listed as a single
+  "Russo Brothers" entry because they always co-direct. TMDb tracks
+  them as separate people, so the filmography is pulled via Anthony
+  Russo's credits to avoid double-counting.
+- Revenue and budget come from TMDb's user-maintained data, which is
+  reliable for major releases but can be missing or zero for older
+  films and limited releases. Films without revenue are excluded from
+  the gross trajectories but included in the vote-average panel and
+  the all-films table.
+- Inflation adjustment uses BLS CPI-U All Urban Consumers (annual
+  averages) and treats the most recent year in the embedded table as
+  the reference. Update once a year alongside the workflow.

--- a/scripts/refresh_director_filmographies.R
+++ b/scripts/refresh_director_filmographies.R
@@ -1,0 +1,234 @@
+#!/usr/bin/env Rscript
+# refresh_director_filmographies.R
+#
+# Pull the directing filmography for a curated list of the 10
+# highest-grossing film directors of all time, hitting the TMDb v3 API.
+#
+# Output:
+#   data/director_filmographies.csv  - long format, one row per (director, film)
+#   data/director_filmographies_meta.csv - small table of director-level metadata
+#
+# Requires:
+#   TMDB_API_KEY env var (a v3 API key, NOT a v4 read access token).
+#
+# Usage:
+#   TMDB_API_KEY=... Rscript scripts/refresh_director_filmographies.R
+
+suppressPackageStartupMessages({
+  library(dplyr)
+  library(tibble)
+  library(stringr)
+  library(readr)
+  library(here)
+  library(httr2)
+  library(jsonlite)
+  library(purrr)
+})
+
+api_key <- Sys.getenv("TMDB_API_KEY", unset = "")
+if (!nzchar(api_key)) {
+  stop("TMDB_API_KEY is not set. Add it to repo secrets and pass it ",
+       "into the workflow env.")
+}
+
+# Curated list of the 10 highest-grossing film directors of all time per
+# Wikipedia / Statista (worldwide, not inflation-adjusted). Sources are
+# updated periodically; ranks past ~2025 may shift as newer films release.
+# The Russo brothers are listed as a duo because they always co-direct.
+directors <- tibble::tribble(
+  ~rank, ~display_name,        ~tmdb_query,            ~force_id,
+  1,     "Steven Spielberg",   "Steven Spielberg",     488L,
+  2,     "James Cameron",      "James Cameron",        2710L,
+  3,     "Russo Brothers",     "Anthony Russo",        19271L,
+  4,     "Peter Jackson",      "Peter Jackson",        108L,
+  5,     "Michael Bay",        "Michael Bay",          865L,
+  6,     "David Yates",        "David Yates",          11544L,
+  7,     "Christopher Nolan",  "Christopher Nolan",    525L,
+  8,     "Ridley Scott",       "Ridley Scott",         578L,
+  9,     "Tim Burton",         "Tim Burton",           510L,
+  10,    "J.J. Abrams",        "J.J. Abrams",          15328L
+)
+
+tmdb_get <- function(path, query = list()) {
+  url <- paste0("https://api.themoviedb.org/3", path)
+  req <- httr2::request(url) |>
+    httr2::req_url_query(!!!c(list(api_key = api_key), query)) |>
+    httr2::req_retry(max_tries = 4, backoff = ~ min(2 ^ .x, 30)) |>
+    httr2::req_throttle(rate = 35 / 10) |>
+    httr2::req_user_agent("cavandonohoe.github.io/director-filmographies")
+  resp <- httr2::req_perform(req)
+  jsonlite::fromJSON(httr2::resp_body_string(resp), simplifyVector = TRUE)
+}
+
+resolve_person_id <- function(query, force_id = NA_integer_) {
+  if (!is.na(force_id)) return(force_id)
+  res <- tmdb_get("/search/person", list(query = query, include_adult = "false"))
+  if (!is.null(res$results) && nrow(res$results) > 0) {
+    return(res$results$id[1])
+  }
+  stop("No TMDb person match for: ", query)
+}
+
+fetch_directing_credits <- function(person_id) {
+  res <- tmdb_get(paste0("/person/", person_id, "/movie_credits"))
+  crew <- res$crew
+  if (is.null(crew) || nrow(crew) == 0) {
+    return(tibble::tibble())
+  }
+  crew |>
+    dplyr::filter(.data$job == "Director") |>
+    dplyr::select(any_of(c("id", "title", "release_date", "popularity"))) |>
+    dplyr::distinct(.data$id, .keep_all = TRUE)
+}
+
+fetch_movie_details <- function(movie_id) {
+  res <- tmdb_get(paste0("/movie/", movie_id))
+  tibble::tibble(
+    id = movie_id,
+    title = res$title %||% NA_character_,
+    release_date = res$release_date %||% NA_character_,
+    runtime = res$runtime %||% NA_integer_,
+    budget = res$budget %||% NA_real_,
+    revenue = res$revenue %||% NA_real_,
+    vote_average = res$vote_average %||% NA_real_,
+    vote_count = res$vote_count %||% NA_integer_,
+    original_language = res$original_language %||% NA_character_,
+    imdb_id = res$imdb_id %||% NA_character_
+  )
+}
+
+`%||%` <- function(a, b) if (is.null(a) || length(a) == 0) b else a
+
+# Annual US CPI-U (1913-2025). Used to convert nominal USD revenue to
+# 2025-equivalent dollars so cross-era comparisons are honest. Source:
+# BLS CPI-U All Urban Consumers, US City Average, annual averages.
+# Refreshing this once a year is sufficient — new films move much more
+# than CPI revisions.
+cpi_table <- tibble::tribble(
+  ~year, ~cpi,
+  1970,   38.8, 1971, 40.5, 1972, 41.8, 1973, 44.4, 1974, 49.3,
+  1975,   53.8, 1976, 56.9, 1977, 60.6, 1978, 65.2, 1979, 72.6,
+  1980,   82.4, 1981, 90.9, 1982, 96.5, 1983, 99.6, 1984, 103.9,
+  1985,  107.6, 1986, 109.6, 1987, 113.6, 1988, 118.3, 1989, 124.0,
+  1990,  130.7, 1991, 136.2, 1992, 140.3, 1993, 144.5, 1994, 148.2,
+  1995,  152.4, 1996, 156.9, 1997, 160.5, 1998, 163.0, 1999, 166.6,
+  2000,  172.2, 2001, 177.1, 2002, 179.9, 2003, 184.0, 2004, 188.9,
+  2005,  195.3, 2006, 201.6, 2007, 207.3, 2008, 215.3, 2009, 214.5,
+  2010,  218.1, 2011, 224.9, 2012, 229.6, 2013, 233.0, 2014, 236.7,
+  2015,  237.0, 2016, 240.0, 2017, 245.1, 2018, 251.1, 2019, 255.7,
+  2020,  258.8, 2021, 271.0, 2022, 292.7, 2023, 304.7, 2024, 313.7,
+  2025,  321.5
+)
+ref_year <- max(cpi_table$year)
+ref_cpi <- cpi_table$cpi[cpi_table$year == ref_year]
+
+inflate_to_ref <- function(usd, year) {
+  cpi <- cpi_table$cpi[match(year, cpi_table$year)]
+  out <- usd * (ref_cpi / cpi)
+  out[is.na(cpi) | is.na(usd)] <- NA_real_
+  out
+}
+
+message(sprintf(
+  "[director-films] Resolving %d directors...", nrow(directors)
+))
+
+directors_resolved <- directors |>
+  dplyr::mutate(
+    person_id = purrr::pmap_int(
+      list(.data$tmdb_query, .data$force_id),
+      function(q, f) resolve_person_id(q, f)
+    )
+  )
+
+message("[director-films] Person IDs:")
+print(directors_resolved |> dplyr::select(rank, display_name, person_id))
+
+all_films <- purrr::pmap_dfr(
+  list(
+    directors_resolved$person_id,
+    directors_resolved$display_name,
+    directors_resolved$rank
+  ),
+  function(person_id, display_name, rank) {
+    message(sprintf("[director-films] Pulling credits for %s (id=%d)...",
+                    display_name, person_id))
+    credits <- fetch_directing_credits(person_id)
+    if (nrow(credits) == 0) {
+      return(tibble::tibble())
+    }
+    details <- purrr::map_dfr(credits$id, fetch_movie_details)
+    dplyr::left_join(details, credits |> dplyr::select(id, popularity),
+                     by = "id") |>
+      dplyr::mutate(
+        director_rank = rank,
+        director_display_name = display_name,
+        director_person_id = person_id
+      )
+  }
+)
+
+# The Russo brothers credit is pulled via Anthony Russo only (id 19271);
+# Joe Russo's directing credits are the same set (they always co-direct).
+# Pulling both would double-count, so we collapse under one display name.
+
+films_clean <- all_films |>
+  dplyr::filter(!is.na(.data$release_date), .data$release_date != "") |>
+  dplyr::mutate(
+    release_year = as.integer(stringr::str_sub(.data$release_date, 1, 4))
+  ) |>
+  dplyr::filter(
+    !is.na(.data$release_year),
+    .data$release_year >= 1960,
+    .data$release_year <= as.integer(format(Sys.Date(), "%Y"))
+  ) |>
+  # Drop films that haven't released revenue data yet (TMDb defaults to 0
+  # for unknowns, which would distort plots). Keep them only if they have
+  # a non-zero vote_count, so vote-average plots can still include them.
+  dplyr::mutate(
+    revenue_usable = .data$revenue > 0,
+    budget_usable = .data$budget > 0,
+    revenue_2025 = inflate_to_ref(.data$revenue, .data$release_year),
+    budget_2025 = inflate_to_ref(.data$budget, .data$release_year)
+  ) |>
+  dplyr::group_by(.data$director_display_name) |>
+  dplyr::arrange(.data$release_date, .by_group = TRUE) |>
+  dplyr::mutate(
+    career_film_number = dplyr::row_number()
+  ) |>
+  dplyr::ungroup() |>
+  dplyr::arrange(.data$director_rank, .data$career_film_number) |>
+  dplyr::select(
+    director_rank, director_display_name, director_person_id,
+    career_film_number, tmdb_id = id, imdb_id, title, release_date,
+    release_year, runtime, budget, revenue, budget_2025, revenue_2025,
+    revenue_usable, budget_usable, vote_average, vote_count,
+    original_language, popularity
+  )
+
+# Director-level rollup so the Rmd doesn't have to recompute it.
+meta <- films_clean |>
+  dplyr::filter(.data$revenue_usable) |>
+  dplyr::group_by(.data$director_rank, .data$director_display_name) |>
+  dplyr::summarise(
+    n_films = dplyr::n(),
+    first_year = min(.data$release_year, na.rm = TRUE),
+    last_year = max(.data$release_year, na.rm = TRUE),
+    lifetime_revenue = sum(.data$revenue, na.rm = TRUE),
+    lifetime_revenue_2025 = sum(.data$revenue_2025, na.rm = TRUE),
+    avg_revenue_per_film = mean(.data$revenue, na.rm = TRUE),
+    avg_revenue_per_film_2025 = mean(.data$revenue_2025, na.rm = TRUE),
+    avg_vote = mean(.data$vote_average[.data$vote_count >= 100], na.rm = TRUE),
+    .groups = "drop"
+  ) |>
+  dplyr::arrange(.data$director_rank)
+
+dir.create(here::here("data"), showWarnings = FALSE, recursive = TRUE)
+
+readr::write_csv(films_clean, here::here("data", "director_filmographies.csv"))
+readr::write_csv(meta, here::here("data", "director_filmographies_meta.csv"))
+
+message(sprintf(
+  "[director-films] Wrote %d films across %d directors. CPI ref year: %d.",
+  nrow(films_clean), nrow(meta), ref_year
+))


### PR DESCRIPTION
## Summary

New page **Director's Box Office Trajectory** under Movies & TV.

Tracks the career trajectories of the 10 highest-grossing film directors of all time (per [Wikipedia](https://en.wikipedia.org/wiki/List_of_highest-grossing_film_directors)): Spielberg, Cameron, Russo Brothers, Peter Jackson, Michael Bay, David Yates, Nolan, Ridley Scott, Tim Burton, J.J. Abrams.

For each director, pulls their full directing filmography from TMDb and shows:

- **Leaderboard** table — lifetime gross (nominal + 2025 USD), avg per film, avg TMDb vote
- **Small-multiples trajectory** by career film number (one panel per director, free y-axes), available in inflation-adjusted, nominal, and TMDb vote-average flavors
- **Top 5 films per director** (sortable)
- **All films** table (sortable, filterable)

Inflation adjustment uses BLS CPI-U All Urban Consumers, embedded as a small annual table in the refresh script.

## Files

- `scripts/refresh_director_filmographies.R` — TMDb API pull + CPI inflation + per-director summary rollup. Throttled and retried.
- `.github/workflows/update_director_filmographies.yml` — monthly cron on the 17th (well-spaced from the 8th/12th refreshes already on the calendar). Commits the CSV when it changes.
- `director_box_office_trajectory.Rmd` — the page. Renders gracefully with a "data not yet available" placeholder when the CSV isn't there yet, so the daily build doesn't break before the first refresh runs.
- `_site.yml` — adds the page to the Movies & TV menu.
- `README.Rmd` / `README.md` — adds page to highlights and the workflow to the automation list.

## Pre-merge action required

**Add a `TMDB_API_KEY` repo secret** before the workflow can succeed.

1. Get a v3 API key from https://www.themoviedb.org/settings/api (free, instant)
2. `gh secret set TMDB_API_KEY --repo cavandonohoe/cavandonohoe.github.io`
3. After merge, manually trigger the workflow once:
   `gh workflow run update_director_filmographies.yml`
4. The next daily site build will pick up the CSV and render the real page.

## Test plan

- [ ] PR preview deploys with the placeholder visible (no data CSV yet)
- [ ] After secret is added, manual workflow run produces `data/director_filmographies.csv` and `data/director_filmographies_meta.csv`
- [ ] Daily site build picks up the CSVs and the page renders all four chart panels + tables
- [ ] Russo Brothers entry contains MCU films (Captain America 2, Civil War, Infinity War, Endgame, etc.) and not duplicate rows from Joe Russo
- [ ] Spielberg shows ~30+ films across his career; vote_average panel includes early-career films like Duel