### PR TITLE
Auto-deploy site after scheduled data refreshes

### DIFF
--- a/.github/workflows/pages-branch-previews.yml
+++ b/.github/workflows/pages-branch-previews.yml
@@ -58,23 +58,30 @@ jobs:
         with:
           dependencies: '"all"'
       
-      # ✅ Write SA key to runner temp for same-repo PRs & pushes (forks won't get secrets)
-      # NOTE: Dependabot PRs run with restricted permissions and DO NOT receive
-      # repo secrets, even though they originate from the same repo. Skip the
-      # SA-JSON write (and the auth check below) for Dependabot to avoid
-      # writing an empty sa.json that fails downstream auth.
+      # ✅ Write SA key to runner temp for same-repo PRs, pushes, and manual
+      # dispatches (forks won't get secrets). NOTE: Dependabot PRs run with
+      # restricted permissions and DO NOT receive repo secrets, even though
+      # they originate from the same repo. Skip the SA-JSON write (and the
+      # auth check below) for Dependabot to avoid writing an empty sa.json
+      # that fails downstream auth.
       - name: Write Google SA JSON
-        if: ${{ ((github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) || (github.event_name == 'push' && github.ref == 'refs/heads/main')) && github.actor != 'dependabot[bot]' }}
+        if: ${{ ((github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) || (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch') && github.actor != 'dependabot[bot]' }}
         run: |
           printf '%s' '${{ secrets.GCP_SA_KEY }}' > "$RUNNER_TEMP/sa.json"
           chmod 600 "$RUNNER_TEMP/sa.json"
 
-      # Optional: sanity check auth when key exists (no-op on forks / Dependabot)
+      # Optional: sanity check auth when key exists (no-op on forks / Dependabot
+      # / any path where Write Google SA JSON didn't run, since the file
+      # won't exist).
       - name: Google auth check
         if: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && github.actor != 'dependabot[bot]' }}
         env:
           GOOGLE_APPLICATION_CREDENTIALS: ${{ runner.temp }}/sa.json
         run: |
+          if [ ! -s "$GOOGLE_APPLICATION_CREDENTIALS" ]; then
+            echo "No SA JSON written for this event; skipping Google auth check."
+            exit 0
+          fi
           Rscript -e 'suppressPackageStartupMessages({library(googledrive);library(googlesheets4)}); drive_auth(path=Sys.getenv("GOOGLE_APPLICATION_CREDENTIALS"), cache=FALSE); gs4_auth(path=Sys.getenv("GOOGLE_APPLICATION_CREDENTIALS"), cache=FALSE)'
 
       # Optional: ensure gs4 guards (matches your other workflow)

--- a/.github/workflows/refresh-sitemap.yml
+++ b/.github/workflows/refresh-sitemap.yml
@@ -35,6 +35,7 @@ jobs:
         run: Rscript scripts/generate_sitemap.R
 
       - name: Commit and push if sitemap changed
+        id: push
         run: |
           set -euo pipefail
           git config user.name "github-actions[bot]"
@@ -42,14 +43,27 @@ jobs:
           git add sitemap.xml
           if git diff --cached --quiet; then
             echo "No sitemap changes."
+            echo "pushed=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           git commit -m "Auto-refresh sitemap.xml"
           # Pull-rebase to avoid losing races with other refresh workflows.
           for i in 1 2 3; do
-            if git push; then exit 0; fi
+            if git push; then
+              echo "pushed=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
             echo "Push failed; rebasing on remote and retrying ($i/3)..."
             git pull --rebase origin "$(git rev-parse --abbrev-ref HEAD)"
           done
           echo "ERROR: failed to push sitemap update after 3 attempts."
           exit 1
+
+      # Bot pushes via GITHUB_TOKEN don't trigger downstream workflows (a
+      # GitHub anti-recursion guard), so the site won't redeploy after this
+      # commit unless we explicitly dispatch the build workflow.
+      - name: Trigger site redeploy
+        if: steps.push.outputs.pushed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh workflow run pages-branch-previews.yml --ref main

--- a/.github/workflows/update_director_filmographies.yml
+++ b/.github/workflows/update_director_filmographies.yml
@@ -55,6 +55,7 @@ jobs:
           fi
 
       - name: Commit and push if changed
+        id: push
         run: |
           set -euo pipefail
           git config user.name "github-actions[bot]"
@@ -62,6 +63,7 @@ jobs:
           git add data/director_filmographies.csv data/director_filmographies_meta.csv
           if git diff --cached --quiet; then
             echo "No changes."
+            echo "pushed=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           n_films="$(wc -l < data/director_filmographies.csv | tr -d ' ')"
@@ -72,9 +74,21 @@ jobs:
           } > /tmp/commit-msg.txt
           git commit -F /tmp/commit-msg.txt
           for i in 1 2 3; do
-            if git push; then exit 0; fi
+            if git push; then
+              echo "pushed=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
             echo "Push failed; rebasing on remote and retrying ($i/3)..."
             git pull --rebase origin "$(git rev-parse --abbrev-ref HEAD)"
           done
           echo "ERROR: failed to push director filmographies update after 3 attempts."
           exit 1
+
+      # Bot pushes via GITHUB_TOKEN don't trigger downstream workflows (a
+      # GitHub anti-recursion guard), so the site won't redeploy after this
+      # commit unless we explicitly dispatch the build workflow.
+      - name: Trigger site redeploy
+        if: steps.push.outputs.pushed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh workflow run pages-branch-previews.yml --ref main

--- a/.github/workflows/update_imdb_ratings.yml
+++ b/.github/workflows/update_imdb_ratings.yml
@@ -68,6 +68,7 @@ jobs:
           git status --porcelain
 
       - name: Commit and push if changed
+        id: push
         run: |
           set -euo pipefail
 
@@ -78,6 +79,7 @@ jobs:
 
           if git diff --cached --quiet; then
             echo "No changes."
+            echo "pushed=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -141,9 +143,21 @@ jobs:
           git commit -F "$summary_file.msg"
           rm -f "$summary_file" "$summary_file.msg"
           for i in 1 2 3; do
-            if git push; then exit 0; fi
+            if git push; then
+              echo "pushed=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
             echo "Push failed; rebasing on remote and retrying ($i/3)..."
             git pull --rebase origin "$(git rev-parse --abbrev-ref HEAD)"
           done
           echo "ERROR: failed to push IMDb ratings update after 3 attempts."
           exit 1
+
+      # Bot pushes via GITHUB_TOKEN don't trigger downstream workflows (a
+      # GitHub anti-recursion guard), so the site won't redeploy after this
+      # commit unless we explicitly dispatch the build workflow.
+      - name: Trigger site redeploy
+        if: steps.push.outputs.pushed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh workflow run pages-branch-previews.yml --ref main

--- a/.github/workflows/update_mymaps_export.yml
+++ b/.github/workflows/update_mymaps_export.yml
@@ -31,6 +31,7 @@ jobs:
           head -n 5 data/saved_places.csv || true
 
       - name: Commit and push if changed
+        id: push
         run: |
           set -euo pipefail
 
@@ -41,14 +42,27 @@ jobs:
 
           if git diff --cached --quiet; then
             echo "No changes."
+            echo "pushed=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
           git commit -m "Auto-update My Maps export"
           for i in 1 2 3; do
-            if git push; then exit 0; fi
+            if git push; then
+              echo "pushed=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
             echo "Push failed; rebasing on remote and retrying ($i/3)..."
             git pull --rebase origin "$(git rev-parse --abbrev-ref HEAD)"
           done
           echo "ERROR: failed to push My Maps export update after 3 attempts."
           exit 1
+
+      # Bot pushes via GITHUB_TOKEN don't trigger downstream workflows (a
+      # GitHub anti-recursion guard), so the site won't redeploy after this
+      # commit unless we explicitly dispatch the build workflow.
+      - name: Trigger site redeploy
+        if: steps.push.outputs.pushed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh workflow run pages-branch-previews.yml --ref main

--- a/.github/workflows/update_sp500.yml
+++ b/.github/workflows/update_sp500.yml
@@ -46,6 +46,7 @@ jobs:
           fi
 
       - name: Commit and push if changed
+        id: push
         run: |
           set -euo pipefail
           git config user.name "github-actions[bot]"
@@ -53,13 +54,26 @@ jobs:
           git add data/voo_stock_prices.csv
           if git diff --cached --quiet; then
             echo "No changes."
+            echo "pushed=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           git commit -m "Auto-update VOO stock prices"
           for i in 1 2 3; do
-            if git push; then exit 0; fi
+            if git push; then
+              echo "pushed=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
             echo "Push failed; rebasing on remote and retrying ($i/3)..."
             git pull --rebase origin "$(git rev-parse --abbrev-ref HEAD)"
           done
           echo "ERROR: failed to push VOO update after 3 attempts."
           exit 1
+
+      # Bot pushes via GITHUB_TOKEN don't trigger downstream workflows (a
+      # GitHub anti-recursion guard), so the site won't redeploy after this
+      # commit unless we explicitly dispatch the build workflow.
+      - name: Trigger site redeploy
+        if: steps.push.outputs.pushed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh workflow run pages-branch-previews.yml --ref main

--- a/.github/workflows/update_top1000_box_office.yml
+++ b/.github/workflows/update_top1000_box_office.yml
@@ -62,6 +62,7 @@ jobs:
           fi
 
       - name: Commit and push if changed
+        id: push
         if: always()
         run: |
           set -euo pipefail
@@ -78,6 +79,7 @@ jobs:
             2>/dev/null || true
           if git diff --cached --quiet; then
             echo "No changes."
+            echo "pushed=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -105,9 +107,21 @@ jobs:
 
           git commit -F /tmp/commit-msg.txt
           for i in 1 2 3; do
-            if git push; then exit 0; fi
+            if git push; then
+              echo "pushed=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
             echo "Push failed; rebasing on remote and retrying ($i/3)..."
             git pull --rebase origin "$(git rev-parse --abbrev-ref HEAD)"
           done
           echo "ERROR: failed to push box office update after 3 attempts."
           exit 1
+
+      # Bot pushes via GITHUB_TOKEN don't trigger downstream workflows (a
+      # GitHub anti-recursion guard), so the site won't redeploy after this
+      # commit unless we explicitly dispatch the build workflow.
+      - name: Trigger site redeploy
+        if: steps.push.outputs.pushed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh workflow run pages-branch-previews.yml --ref main

--- a/.github/workflows/update_top250_with_rt.yml
+++ b/.github/workflows/update_top250_with_rt.yml
@@ -55,6 +55,7 @@ jobs:
           fi
 
       - name: Commit and push if changed
+        id: push
         run: |
           set -euo pipefail
           git config user.name "github-actions[bot]"
@@ -62,13 +63,26 @@ jobs:
           git add data/top250_movies_with_rt.csv
           if git diff --cached --quiet; then
             echo "No changes."
+            echo "pushed=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           git commit -m "Auto-update Top 250 movies with Rotten Tomatoes"
           for i in 1 2 3; do
-            if git push; then exit 0; fi
+            if git push; then
+              echo "pushed=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
             echo "Push failed; rebasing on remote and retrying ($i/3)..."
             git pull --rebase origin "$(git rev-parse --abbrev-ref HEAD)"
           done
           echo "ERROR: failed to push Top 250 update after 3 attempts."
           exit 1
+
+      # Bot pushes via GITHUB_TOKEN don't trigger downstream workflows (a
+      # GitHub anti-recursion guard), so the site won't redeploy after this
+      # commit unless we explicitly dispatch the build workflow.
+      - name: Trigger site redeploy
+        if: steps.push.outputs.pushed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh workflow run pages-branch-previews.yml --ref main

--- a/.github/workflows/update_us_rentals.yml
+++ b/.github/workflows/update_us_rentals.yml
@@ -48,6 +48,7 @@ jobs:
           fi
 
       - name: Commit and push if changed
+        id: push
         run: |
           set -euo pipefail
           git config user.name "github-actions[bot]"
@@ -55,13 +56,26 @@ jobs:
           git add data/us_rental_markets.csv
           if git diff --cached --quiet; then
             echo "No changes."
+            echo "pushed=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           git commit -m "Auto-update US rental markets data"
           for i in 1 2 3; do
-            if git push; then exit 0; fi
+            if git push; then
+              echo "pushed=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
             echo "Push failed; rebasing on remote and retrying ($i/3)..."
             git pull --rebase origin "$(git rev-parse --abbrev-ref HEAD)"
           done
           echo "ERROR: failed to push rentals update after 3 attempts."
           exit 1
+
+      # Bot pushes via GITHUB_TOKEN don't trigger downstream workflows (a
+      # GitHub anti-recursion guard), so the site won't redeploy after this
+      # commit unless we explicitly dispatch the build workflow.
+      - name: Trigger site redeploy
+        if: steps.push.outputs.pushed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh workflow run pages-branch-previews.yml --ref main


### PR DESCRIPTION
## Problem

Pushes made with `GITHUB_TOKEN` don't trigger downstream workflows (GitHub's anti-recursion guard). Every scheduled data refresh on this repo commits with `GITHUB_TOKEN`, so the data lands on `main` but `pages-branch-previews.yml` (the prod deploy) never rebuilds. The live site only picks up new data when a separate human/PR push to `main` happens to land afterwards.

Concrete recent example:
- 2026-06-08 12:47 UTC — IMDb ratings auto-update lands on `main` ✅
- 2026-06-08 17:30 UTC — Top 1000 box office auto-update lands on `main` ✅
- Last `pages-branch-previews` deploy: 2026-06-07 21:03 UTC (a manual empty commit) ❌

Separately, manually re-deploying via `gh workflow run pages-branch-previews.yml` was failing because the "Write Google SA JSON" step's condition didn't include `workflow_dispatch`, but the auth check that follows did — so the auth check tried to read a file that was never written.

## Changes

1. **`pages-branch-previews.yml`**
   - Include `workflow_dispatch` in the "Write Google SA JSON" condition.
   - Make "Google auth check" a no-op when the SA JSON file isn't present, defensively.

2. **Each direct-push refresh workflow** now sets a `pushed=true` step output when it actually pushes a commit, then dispatches `pages-branch-previews.yml` against `main` via `gh workflow run`. This fires a real `workflow_dispatch` event (allowed even from another workflow's `GITHUB_TOKEN`), so the site redeploys automatically after every successful data refresh.

   Touched: `update_top1000_box_office.yml`, `update_imdb_ratings.yml`, `update_director_filmographies.yml`, `update_us_rentals.yml`, `update_top250_with_rt.yml`, `update_sp500.yml`, `update_mymaps_export.yml`, `refresh-sitemap.yml`.

## Intentionally not touched

`update_best_picture_winners.yml` and `rebuild_cv.yml` use `peter-evans/create-pull-request`, so the eventual PR merge generates a real `push` event that already triggers a redeploy.

## Verification

- All workflow YAML parses cleanly with `yaml.safe_load`.
- No newly-introduced lines exceed the file's existing line-length style.
- Step output gating (`steps.push.outputs.pushed == 'true'`) is the documented GitHub Actions pattern, ensuring the redeploy only fires when something actually got pushed.

Once merged, the merge itself generates a `push` event that will redeploy the site, picking up today's already-pushed data refreshes (top1000 box office + IMDb ratings).