### PR TITLE
Retire pages-rmarkdown.yml deploy job (fix Pages deploy race)

### DIFF
--- a/.github/workflows/pages-rmarkdown.yml
+++ b/.github/workflows/pages-rmarkdown.yml
@@ -1,9 +1,14 @@
-name: Build & Deploy R Markdown site
+name: Build R Markdown site (sanity check)
 
+# NOTE: Deployment to GitHub Pages is handled by
+# pages-branch-previews.yml, which pushes to the gh-pages branch.
+# This workflow is kept as a safety-net build (DESCRIPTION checks,
+# library() validation, gs4 guards, daily scheduled render). Running
+# both workflows' deploys on the same push to main caused a Pages
+# deployment race ("Deployment request failed ... due to in progress
+# deployment"), so this one no longer deploys.
 on:
   push:
-    branches: ["main"]
-  pull_request:
     branches: ["main"]
   workflow_dispatch:
   schedule:
@@ -11,8 +16,6 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
   pull-requests: write
 
 concurrency:
@@ -56,13 +59,13 @@ jobs:
           dependencies: '"all"'
       # --- Write SA key from repo secret (skip on Dependabot/forks: no secrets) ---
       - name: Write GCP key
-        if: ${{ github.actor != 'dependabot[bot]' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
+        if: ${{ github.actor != 'dependabot[bot]' }}
         run: |
           echo '${{ secrets.GCP_SA_KEY }}' > sa.json
 
       # --- Quick auth sanity check (skipped when no SA key was written) ---
       - name: Google auth (sanity check)
-        if: ${{ github.actor != 'dependabot[bot]' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
+        if: ${{ github.actor != 'dependabot[bot]' }}
         run: |
           Rscript -e 'googledrive::drive_auth(path="sa.json", cache=FALSE); googlesheets4::gs4_auth(path="sa.json", cache=FALSE); googledrive::drive_user()'
 
@@ -101,9 +104,7 @@ jobs:
       - name: Verify gs4 guards are present
         run: Rscript scripts/ensure_gs4_guards.R
 
-      # If you DO render PDFs on CI, keep these two lines. Otherwise, remove Setup Chrome and the env block below.
       - name: Setup Chrome
-        if: ${{ github.event_name != 'pull_request' || github.ref == 'refs/heads/main' }}
         id: chrome
         uses: browser-actions/setup-chrome@v2
         with:
@@ -114,36 +115,3 @@ jobs:
           CHROMOTE_CHROME: ${{ steps.chrome.outputs.chrome-path }}
         run: |
           Rscript -e 'if (file.exists("sa.json")) { googledrive::drive_auth(path="sa.json", cache=FALSE); googlesheets4::gs4_auth(path="sa.json", cache=FALSE) } else { googlesheets4::gs4_deauth() }; rmarkdown::render_site(encoding="UTF-8")'
-
-
-      - name: Upload Pages artifact
-        if: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/main' }}
-        uses: actions/upload-pages-artifact@v5
-        with:
-          path: _site
-
-  deploy:
-    name: Deploy to GitHub Pages
-    needs: build
-    runs-on: ubuntu-latest
-    if: ${{ github.ref == 'refs/heads/main' }}   # ✅ main only
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}   # shows the preview URL in the job UI
-    permissions:
-      pages: write
-      id-token: write
-      pull-requests: write
-    steps:
-      - name: Deploy
-        id: deployment
-        uses: actions/deploy-pages@v5
-      
-      - name: Comment preview URL
-        if: ${{ github.event_name == 'pull_request' }}
-        uses: thollander/actions-comment-pull-request@v3
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          message: "🚀 Preview: ${{ steps.deployment.outputs.page_url }}"
-          mode: upsert
-          create-if-not-exists: true

--- a/README.Rmd
+++ b/README.Rmd
@@ -60,8 +60,13 @@ manual is a click away on the Actions tab.
 
 ### Site build & previews
 
-* `pages-rmarkdown.yml` -- daily site render + GitHub Pages deploy.
-* `pages-branch-previews.yml` -- per-PR preview deploy and cleanup.
+* `pages-branch-previews.yml` -- main deploy + per-PR preview deploy
+  and cleanup. This is what publishes the site (pushes to the
+  `gh-pages` branch).
+* `pages-rmarkdown.yml` -- daily safety-net build with DESCRIPTION /
+  `library()` validation and gs4 guard checks. Does **not** deploy
+  (deploy is owned by `pages-branch-previews.yml` to avoid Pages
+  deployment races).
 
 ### Data refreshes (commits to `main`)
 

--- a/README.md
+++ b/README.md
@@ -67,8 +67,13 @@ manual is a click away on the Actions tab.
 
 ### Site build & previews
 
-- `pages-rmarkdown.yml` – daily site render + GitHub Pages deploy.
-- `pages-branch-previews.yml` – per-PR preview deploy and cleanup.
+- `pages-branch-previews.yml` – main deploy + per-PR preview deploy and
+  cleanup. This is what publishes the site (pushes to the `gh-pages`
+  branch).
+- `pages-rmarkdown.yml` – daily safety-net build with DESCRIPTION /
+  `library()` validation and gs4 guard checks. Does **not** deploy
+  (deploy is owned by `pages-branch-previews.yml` to avoid Pages
+  deployment races).
 
 ### Data refreshes (commits to `main`)
 
@@ -119,8 +124,8 @@ above. Regenerated each time `README.Rmd` is knit.
 
 <img src="images/readme/commit-activity-1.png" alt="Two bar charts showing monthly commits and monthly lines changed (insertions + deletions) for this repository, split by Cavan's own commits vs. scheduled-bot commits."  />
 
-*511 commits since Dec 2020 — 489 by me, 22 by scheduled bots — touching
-1,992,425 lines in total.*
+*510 commits since Dec 2020 — 488 by me, 22 by scheduled bots — touching
+1,992,400 lines in total.*
 
 ## Setup and Local Development
 


### PR DESCRIPTION
## Summary

Two workflows have been racing on every push to \`main\`:

- \`pages-branch-previews.yml\` deploys by pushing the rendered \`_site/\` to the \`gh-pages\` branch
- \`pages-rmarkdown.yml\` deploys via \`actions/deploy-pages\` (the GitHub Pages "environment" API)

Whichever finished first won. The other one would fail with:

\`\`\`
HttpError: Deployment request failed for <sha> due to in progress deployment.
Please cancel <other-sha> first or wait for it to complete.
\`\`\`

The site itself was always fine because the winning deploy published the right artifact, but every push to \`main\` left a red ❌ in the Actions tab. This PR drops the deploy half of \`pages-rmarkdown.yml\` so there's a single deploy path.

## What this PR does

\`pages-rmarkdown.yml\` now:

- Drops the \`deploy\` job
- Drops the \`upload-pages-artifact\` step
- Drops the \`pull_request\` trigger (PR builds + previews are already owned by \`pages-branch-previews.yml\`)
- Renames the workflow to "Build R Markdown site (sanity check)"
- Keeps the build job: DESCRIPTION token validation, DESCRIPTION-vs-\`library()\` validation, gs4 guards, daily 12:11 UTC scheduled render

\`pages-branch-previews.yml\` is unchanged and remains the sole deploy path.

## Test plan

- [x] YAML validates (\`python3 -c "import yaml; yaml.safe_load(...)"\`)
- [ ] CI on this PR is green (only the now-PR-trigger-less workflow should be absent vs. previous PRs)
- [ ] After merge, push to \`main\` no longer produces a \`Build & Deploy R Markdown site\` failure on the deploy step