### PR TITLE
Rebuild Learn R as a real mini-course

### DIFF
--- a/_site.yml
+++ b/_site.yml
@@ -67,18 +67,24 @@ navbar:
         href: sp500.html
       - text: "Covid Cases: Then & Now"
         href: covid_cases_nostalgia.html
-      - text: "Learn R"
-        menu:
-        - text: "R Time Is Limited, Let's Make the Most of It"
-          href: learn_r.html
-        - text: "Intro to R"
-          href: intro_to_r.html
-        - text: "Basic Operations"
-          href: basic_operations_r.html
-        - text: "Data Manipulations"
-          href: data_manipulation_r.html
-        - text: "Data Visualization"
-          href: data_visualization_r.html
-        - text: "Statistics with R"
-          href: statistics_with_r.html
+    - text: "Learn R"
+      icon: fa-graduation-cap
+      menu:
+      - text: "Course Overview"
+        href: learn_r.html
+      - text: "--- Lessons ---"
+      - text: "1. Introduction to R"
+        href: intro_to_r.html
+      - text: "2. Basic Operations"
+        href: basic_operations_r.html
+      - text: "3. Data Manipulation"
+        href: data_manipulation_r.html
+      - text: "4. Data Visualization"
+        href: data_visualization_r.html
+      - text: "5. Statistics with R"
+        href: statistics_with_r.html
+      - text: "6. Reproducible Reports with R Markdown"
+        href: rmarkdown_r.html
+      - text: "7. Capstone Project"
+        href: capstone_r.html
     

--- a/basic_operations_r.Rmd
+++ b/basic_operations_r.Rmd
@@ -1,6 +1,7 @@
 ---
-title: "Basic Operations in R"
+title: "Lesson 2: Basic Operations in R"
 author: "Cavan Donohoe"
+description: "Variables, data types, vectors, comparisons, control flow, and writing your first function."
 output:
   html_document:
     toc: true
@@ -11,110 +12,410 @@ output:
 lang: "en"
 ---
 
+<link rel="stylesheet" href="/css/learn-r.css">
+
+<div class="course-progress">
+Lesson 2 of 7 · <a href="learn_r.html">Course overview</a>
+</div>
+
+```{r setup, include=FALSE}
+options(scipen = 999)
+knitr::opts_chunk$set(comment = "#>")
+```
+
 # Basic Operations in R
 
-In this section, we will dive into the fundamental operations in R, including variables and data types, arithmetic operations, and working with vectors and matrices.
+This lesson covers the building blocks: variables, data types, vectors, operators, control flow, and functions. None of it is exciting on its own, but every single thing in R is built out of these pieces. Get comfortable here and the rest of the course is mostly pattern-matching.
 
-## Variables and Data Types
+## Variables and assignment
 
-In R, variables are used to store data. Before we can perform operations on data, we need to understand different data types. Here are some common data types in R:
-
-- **Numeric**: Used for numbers with decimal points.
-- **Integer**: Used for whole numbers.
-- **Character**: Used for text and strings.
-- **Logical**: Used for Boolean values (TRUE or FALSE).
-
-Let's see some examples:
-
-```R
-# Numeric
-num_var <- 3.14
-
-# Integer
-int_var <- 42L
-
-# Character
-char_var <- "Hello, R!"
-
-# Logical
-logical_var <- TRUE
-```
-
-## Arithmetic Operations
-R allows you to perform a wide range of arithmetic operations on numeric data. Here are some basic operations:
-
-- Addition (+)
-- Subtraction (-)
-- Multiplication (*)
-- Division (/)
-- Exponentiation (^)
-- Modulo (%%)
-
-```{r include=FALSE}
-options(scipen = 999)
-```
-
+A **variable** is a name that points to a value. Assign with `<-`:
 
 ```{r}
-# Examples of arithmetic operations
-x <- 10
-y <- 5
-
-addition_result <- x + y
-addition_result
-
-subtraction_result <- x - y
-subtraction_result
-
-multiplication_result <- x * y
-multiplication_result
-
-division_result <- x / y
-division_result
-
-exponentiation_result <- x ^ y
-exponentiation_result
-
-modulo_result <- x %% y
-modulo_result
+x <- 5
+y <- 12
+x + y
 ```
 
+`=` works too, but `<-` is the convention in R for assignment. Stick with it.
 
-## Working with Vectors and Matrices
-Vectors and matrices are fundamental data structures in R that allow you to work with collections of data efficiently.
-
-### Vectors
-A vector is a one-dimensional array that can hold elements of the same data type. You can create vectors using the c() function:
-
-```R
-# Creating a numeric vector
-numeric_vector <- c(1, 2, 3, 4, 5)
-
-# Creating a character vector
-char_vector <- c("apple", "banana", "cherry")
-```
-
-### Matrices
-A matrix is a two-dimensional array that can hold elements of the same data type. You can create matrices using the matrix() function:
-
+You can reassign a variable as often as you like — R doesn't care:
 
 ```{r}
-# Creating a matrix
-matrix_data <- matrix(1:6, nrow = 2, ncol = 3)
-matrix_data
+x <- 5
+x <- x + 1
+x
 ```
 
-These are the basics of working with variables, data types, arithmetic operations, vectors, and matrices in R. In the next sections, we will explore more advanced topics and practical examples.
+## Data types
 
-Feel free to practice these concepts in your R environment to solidify your understanding.
+R has a small set of basic types you'll use constantly.
 
+```{r}
+n  <- 3.14         # numeric (double)
+i  <- 42L          # integer (the L makes it an integer, not a double)
+s  <- "hello"      # character (string)
+b  <- TRUE         # logical (TRUE / FALSE)
+m  <- NA           # missing value
+```
 
-Free Lessons:
+To check what type something is, use `class()` or one of the `is.*` family:
 
-- [R Time Is Limited, Let's Make the Most of It](https://cavandonohoe.github.io/learn_r.html)
-- [Introduction to R](https://cavandonohoe.github.io/intro_to_r.html)
-- [Basic Operations in R](https://cavandonohoe.github.io/basic_operations_r.html)
-- [Data Manipulation](https://cavandonohoe.github.io/data_manipulation_r.html)
-- [Data Visualization](https://cavandonohoe.github.io/data_visualization_r.html)
-- [Statistics in R](https://cavandonohoe.github.io/statistics_with_r.html)
+```{r}
+class(n)
+class(s)
+class(b)
+is.numeric(n)
+is.character(s)
+```
 
+Missing values (`NA`) are everywhere in real data. R takes them seriously — most functions return `NA` if their input has any `NA`s, unless you tell them otherwise:
+
+```{r}
+mean(c(1, 2, NA))
+mean(c(1, 2, NA), na.rm = TRUE)
+```
+
+<div class="callout callout-warning">
+<div class="callout-title">⚠️ <code>NA</code> is contagious</div>
+`NA == NA` is `NA`, not `TRUE`. To check for missingness use `is.na(x)`. This trips up beginners constantly.
+</div>
+
+## Arithmetic and math
+
+The usual suspects:
+
+```{r}
+10 + 3
+10 - 3
+10 * 3
+10 / 3
+10 %% 3   # remainder (modulo)
+10 %/% 3  # integer division
+10 ^ 3    # exponentiation
+```
+
+Plus a stack of built-in math functions:
+
+```{r}
+sqrt(16)
+log(100)        # natural log
+log(100, base = 10)
+exp(1)          # e
+abs(-7)
+round(3.14159, 2)
+ceiling(2.1)
+floor(2.9)
+```
+
+## Comparison and logical operators
+
+Comparisons return `TRUE` or `FALSE`:
+
+```{r}
+5 > 3
+5 == 5     # equality is double-equals; single-equals is assignment
+5 != 6
+5 >= 5
+"a" < "b"  # alphabetical
+```
+
+Logical operators combine `TRUE`/`FALSE` values:
+
+```{r}
+TRUE & FALSE   # AND
+TRUE | FALSE   # OR
+!TRUE          # NOT
+```
+
+The single-character versions (`&`, `|`) work elementwise on vectors. The double-character versions (`&&`, `||`) only look at the first element and short-circuit — use them inside `if` statements, not for filtering data.
+
+## Vectors
+
+A **vector** is an ordered collection of values, all of the same type. It's the most fundamental data structure in R — even a single number is technically a vector of length 1.
+
+Create a vector with `c()` ("combine"):
+
+```{r}
+ages <- c(23, 31, 27, 45, 19)
+fruit <- c("apple", "banana", "cherry")
+flags <- c(TRUE, FALSE, TRUE, TRUE)
+```
+
+A few handy ways to create vectors:
+
+```{r}
+1:5                  # integer sequence
+seq(0, 1, by = 0.25)
+rep("a", times = 3)
+```
+
+### Indexing vectors
+
+Subsetting a vector by position uses `[ ]`. **R is 1-indexed** — the first element is at position 1, not 0.
+
+```{r}
+ages[1]            # first element
+ages[c(1, 3)]      # first and third
+ages[-1]           # everything except the first (negative indexing drops)
+ages[ages > 25]    # elements that match a condition
+```
+
+That last one — subsetting by a logical vector — is one of the most-used patterns in R. The expression `ages > 25` returns a logical vector the same length as `ages`, and `ages[...]` keeps the elements where it's `TRUE`.
+
+### Vectorized operations
+
+R operations work on entire vectors at once. You almost never need a loop for elementwise math:
+
+```{r}
+ages
+ages + 1            # add 1 to every element
+ages * 2
+ages > 30
+sum(ages)
+mean(ages)
+length(ages)
+```
+
+This is the single biggest stylistic difference between R and most other languages, and getting comfortable with it is half the battle.
+
+### Named vectors
+
+Vectors can have names attached to each element:
+
+```{r}
+prices <- c(apple = 1.20, banana = 0.50, cherry = 3.00)
+prices
+prices["banana"]
+```
+
+## Lists
+
+A **list** is like a vector, but each element can be a different type — even another list.
+
+```{r}
+person <- list(name = "Ada", age = 36, hobbies = c("math", "logic"))
+person$name
+person$hobbies
+person[["age"]]
+```
+
+You'll meet lists most often as the return value of model-fitting functions like `lm()` (we'll get there in Lesson 5).
+
+## Data frames
+
+A **data frame** is a table — rows are observations, columns are variables, and each column is a vector of the same length. It's the workhorse data structure for most analysis.
+
+```{r}
+df <- data.frame(
+  name = c("Alice", "Bob", "Charlie"),
+  age = c(25, 30, 22),
+  score = c(95, 88, 75)
+)
+df
+```
+
+Subset by column with `$` or `[[ ]]`, and by row/column with `[ , ]`:
+
+```{r}
+df$age
+df[1, ]            # first row
+df[, "name"]       # name column
+df[df$age > 23, ]  # all rows where age > 23
+```
+
+We'll spend most of Lesson 3 working with data frames using a much nicer toolset (`dplyr`). For now, just know they exist and look like a spreadsheet.
+
+## Control flow
+
+### `if` / `else`
+
+```{r}
+score <- 78
+if (score >= 90) {
+  "A"
+} else if (score >= 80) {
+  "B"
+} else if (score >= 70) {
+  "C"
+} else {
+  "F"
+}
+```
+
+### `for` loops
+
+```{r}
+for (n in 1:5) {
+  print(n^2)
+}
+```
+
+<div class="callout callout-tip">
+<div class="callout-title">💡 You'll write fewer loops than you think</div>
+In R, most things you'd loop over in another language can be done with vectorized operations or with `sapply`/`lapply`. Loops aren't wrong — they're just often unnecessary. We'll see this in Lesson 3.
+</div>
+
+### `while` loops
+
+```{r}
+n <- 1
+while (n < 100) {
+  n <- n * 2
+}
+n
+```
+
+## Functions
+
+Writing your own functions is how you go from "running examples" to "actually using R for something." Syntax:
+
+```{r}
+celsius_to_fahrenheit <- function(c) {
+  c * 9 / 5 + 32
+}
+
+celsius_to_fahrenheit(0)
+celsius_to_fahrenheit(c(0, 20, 100))   # works on a vector for free
+```
+
+A few rules:
+
+- The last expression in the body is what the function returns. You can also write `return(...)` explicitly, but it's not required.
+- Arguments can have default values: `function(c, offset = 0) { ... }`.
+- Functions are first-class — you can pass them around as values.
+
+A slightly more useful one — given a numeric vector, compute summary stats:
+
+```{r}
+quick_summary <- function(x, na_rm = TRUE) {
+  list(
+    n = length(x),
+    n_missing = sum(is.na(x)),
+    mean = mean(x, na.rm = na_rm),
+    sd = sd(x, na.rm = na_rm),
+    min = min(x, na.rm = na_rm),
+    max = max(x, na.rm = na_rm)
+  )
+}
+
+quick_summary(c(2, 4, 6, 8, 10, NA))
+```
+
+## Putting it together
+
+Let's combine everything in this lesson into a tiny analysis. Given a vector of test scores, classify each into a letter grade and report how many of each.
+
+```{r}
+scores <- c(72, 88, 95, 67, 81, 59, 91, 78, 84, 100)
+
+grade <- function(score) {
+  if (score >= 90) {
+    "A"
+  } else if (score >= 80) {
+    "B"
+  } else if (score >= 70) {
+    "C"
+  } else if (score >= 60) {
+    "D"
+  } else {
+    "F"
+  }
+}
+
+grades <- sapply(scores, grade)
+grades
+
+table(grades)
+```
+
+`sapply` applies a function to each element of a vector and returns the results. We need it here because `grade()` uses `if`, which only works on a single value at a time. (In Lesson 3 we'll see a much cleaner way to do this with `dplyr::case_when()`.)
+
+<div class="exercise">
+<div class="exercise-title">✏️ Exercise 2.1 — Vectorized math</div>
+
+Given the temperatures vector below (in Fahrenheit), convert all of them to Celsius without writing a loop.
+
+```{r eval=FALSE}
+temps_f <- c(32, 50, 68, 86, 104)
+```
+
+<details>
+<summary>Show solution</summary>
+
+```{r}
+temps_f <- c(32, 50, 68, 86, 104)
+temps_c <- (temps_f - 32) * 5 / 9
+temps_c
+```
+
+Or wrap it in a function so you can reuse it:
+
+```{r}
+fahrenheit_to_celsius <- function(f) (f - 32) * 5 / 9
+fahrenheit_to_celsius(temps_f)
+```
+
+</details>
+</div>
+
+<div class="exercise">
+<div class="exercise-title">✏️ Exercise 2.2 — Subsetting</div>
+
+Using the built-in `mtcars` dataset:
+
+1. Print the `mpg` column.
+2. Print only the cars with `mpg > 25`.
+3. What's the mean `mpg` of cars with 4 cylinders (`cyl == 4`)?
+
+<details>
+<summary>Show solution</summary>
+
+```{r}
+mtcars$mpg
+
+mtcars[mtcars$mpg > 25, ]
+
+mean(mtcars$mpg[mtcars$cyl == 4])
+```
+
+</details>
+</div>
+
+<div class="exercise">
+<div class="exercise-title">✏️ Exercise 2.3 — Write a function</div>
+
+Write a function `is_leap_year(year)` that returns `TRUE` if `year` is a leap year and `FALSE` otherwise. (A year is a leap year if it's divisible by 4, *except* century years are only leap years if also divisible by 400. So 2000 is, 1900 isn't.)
+
+Test it on `c(2000, 1900, 2020, 2023, 2024)`.
+
+<details>
+<summary>Show solution</summary>
+
+```{r}
+is_leap_year <- function(year) {
+  (year %% 4 == 0 & year %% 100 != 0) | (year %% 400 == 0)
+}
+
+is_leap_year(c(2000, 1900, 2020, 2023, 2024))
+```
+
+Note we used `&` and `|` (single character) so it works on a whole vector at once — exactly the vectorization point from earlier.
+
+</details>
+</div>
+
+## What's next
+
+You now have variables, types, vectors, control flow, and functions. That's enough to write real code. Lesson 3 introduces the **tidyverse** — a much nicer way to manipulate data frames than what you saw above.
+
+<div class="lesson-nav">
+  <a class="nav-prev" href="intro_to_r.html">
+    <span class="lesson-nav-label">← Previous</span>
+    <span class="lesson-nav-title">Lesson 1: Introduction to R</span>
+  </a>
+  <a class="nav-next" href="data_manipulation_r.html">
+    <span class="lesson-nav-label">Next →</span>
+    <span class="lesson-nav-title">Lesson 3: Data Manipulation</span>
+  </a>
+</div>

--- a/capstone_r.Rmd
+++ b/capstone_r.Rmd
@@ -1,0 +1,297 @@
+---
+title: "Lesson 7: Capstone Project"
+author: "Cavan Donohoe"
+description: "Put it all together: explore a real dataset, model it, and write up a short report — start to finish."
+output:
+  html_document:
+    toc: true
+    toc_float: true
+    includes:
+      in_header: header/header.html
+      after_body: include_footer.html
+lang: "en"
+---
+
+<link rel="stylesheet" href="/css/learn-r.css">
+
+<div class="course-progress">
+Lesson 7 of 7 · <a href="learn_r.html">Course overview</a>
+</div>
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(
+  comment = "#>",
+  message = FALSE,
+  warning = FALSE,
+  fig.width = 6.5,
+  fig.height = 4.2,
+  dpi = 100
+)
+options(scipen = 999, digits = 4)
+```
+
+# Capstone: A Real Analysis, Start to Finish
+
+Time to put it all together. We'll walk through a complete mini-analysis — the kind of thing you might do as a first pass on a real-world dataset. Every step uses something from a previous lesson:
+
+- **Lesson 1:** install packages, run a script.
+- **Lesson 2:** vectors, types, missing values.
+- **Lesson 3:** load and reshape data with the tidyverse.
+- **Lesson 4:** plot with ggplot2.
+- **Lesson 5:** descriptive stats, t-test, regression.
+- **Lesson 6:** wrap it up as an R Markdown report.
+
+The dataset is `airquality` — a built-in R dataset of daily air-quality measurements from New York City, May–September 1973. It's small (153 days), it has missing values, and it has both numeric and categorical variables. Realistic enough to be useful, small enough to fit on this page.
+
+## The question
+
+> **Does ozone concentration in NYC depend on temperature, and if so, how much?**
+
+That gives us a clear target variable (ozone), a candidate predictor (temperature), and a real comparison to make. Along the way we'll also peek at how ozone varies by month.
+
+## Step 1 — Load the data
+
+`airquality` is built into R, so no download needed. Let's get a clean tibble with proper dates.
+
+```{r}
+library(dplyr)
+library(tidyr)
+library(ggplot2)
+
+aq <- airquality |>
+  tibble::as_tibble() |>
+  mutate(
+    date = as.Date(paste("1973", Month, Day, sep = "-")),
+    Month = factor(Month,
+      levels = 5:9,
+      labels = c("May", "Jun", "Jul", "Aug", "Sep")
+    )
+  )
+
+aq
+```
+
+Two real-world things just happened:
+
+- We built a proper `date` column from the `Year`/`Month`/`Day` parts using `as.Date()` and `paste()`.
+- We turned `Month` into a factor with sensible labels, so plots and tables show "Jul" instead of `7`.
+
+## Step 2 — Look at the shape of the data
+
+Always start with `summary()` and a count of missing values:
+
+```{r}
+summary(aq)
+
+aq |>
+  summarise(across(everything(), ~ sum(is.na(.x))))
+```
+
+Two things jump out:
+
+- `Ozone` has 37 missing values out of 153 days (about 24%).
+- `Solar.R` has a few missing too. Temperature and wind are complete.
+
+Missing data isn't necessarily a problem — but you have to know it's there. R's modeling functions handle `NA` differently depending on the function, and most plots silently drop missing rows.
+
+## Step 3 — Visual exploration
+
+Before fitting any model, *look* at the data. A scatterplot of ozone vs. temperature, colored by month:
+
+```{r}
+ggplot(aq, aes(x = Temp, y = Ozone, color = Month)) +
+  geom_point(size = 2.5, alpha = 0.85) +
+  geom_smooth(method = "lm", se = FALSE, color = "black", linewidth = 0.7) +
+  labs(
+    title = "Ozone concentration vs. temperature, NYC 1973",
+    x = "Daily max temperature (°F)",
+    y = "Ozone (ppb)",
+    color = "Month",
+    caption = "Source: New York State Department of Conservation, via R's airquality dataset."
+  ) +
+  theme_minimal(base_size = 12) +
+  theme(plot.caption = element_text(color = "grey50", hjust = 0))
+```
+
+Two observations from this plot alone:
+
+1. **Ozone clearly increases with temperature** — and it's not linear. The relationship looks like a curve, accelerating at higher temperatures.
+2. **The high-ozone days happen mostly in July and August**, which makes sense because those are the hottest months.
+
+Let's also look at ozone by month directly:
+
+```{r}
+ggplot(aq, aes(x = Month, y = Ozone, fill = Month)) +
+  geom_boxplot() +
+  labs(
+    title = "Ozone by month, NYC 1973",
+    x = NULL, y = "Ozone (ppb)"
+  ) +
+  theme_minimal() +
+  theme(legend.position = "none")
+```
+
+July and August are noticeably higher and have a wider spread.
+
+## Step 4 — Descriptive statistics
+
+```{r}
+aq |>
+  group_by(Month) |>
+  summarise(
+    n = n(),
+    n_missing = sum(is.na(Ozone)),
+    mean_ozone = mean(Ozone, na.rm = TRUE),
+    median_ozone = median(Ozone, na.rm = TRUE),
+    sd_ozone = sd(Ozone, na.rm = TRUE),
+    .groups = "drop"
+  )
+```
+
+July and August have mean ozone roughly 2× the May/September values. May has the most missing days (probably equipment ramp-up at the start of the season, but we'd want to ask).
+
+## Step 5 — Quantify it: a t-test
+
+Are July ozone levels different from September? Quick t-test:
+
+```{r}
+jul_sep <- aq |> filter(Month %in% c("Jul", "Sep"))
+t.test(Ozone ~ Month, data = jul_sep)
+```
+
+The mean July ozone is about 50 ppb higher than September, with a tight 95% CI. The p-value is tiny — well below any reasonable threshold for "different."
+
+## Step 6 — Build a model
+
+Linear regression: predict ozone from temperature. Because the relationship in the scatterplot looked curved, let's fit two models and compare.
+
+```{r}
+fit_linear <- lm(Ozone ~ Temp, data = aq)
+fit_quadratic <- lm(Ozone ~ Temp + I(Temp^2), data = aq)
+
+summary(fit_linear)
+summary(fit_quadratic)
+```
+
+The quadratic model has a noticeably higher R-squared and a significant `I(Temp^2)` coefficient, confirming what the scatterplot suggested: ozone grows *faster than linearly* with temperature.
+
+Compare the two models formally:
+
+```{r}
+anova(fit_linear, fit_quadratic)
+```
+
+Tiny p-value — the quadratic term is pulling weight. Use the quadratic model.
+
+## Step 7 — Diagnostics
+
+Before trusting the model, check the standard diagnostic plots:
+
+```{r fig.width=7, fig.height=5}
+par(mfrow = c(2, 2))
+plot(fit_quadratic)
+par(mfrow = c(1, 1))
+```
+
+Things to notice:
+
+- **Residuals vs. Fitted** — mostly flat with no obvious pattern, good sign.
+- **Q-Q plot** — close to the diagonal in the middle but the tails depart, especially the upper tail. The model under-predicts the worst ozone days. That's worth flagging.
+- **Scale-Location** — variance increases with fitted value (heteroscedasticity). A log transform of `Ozone` would probably help.
+
+A quick sanity-check fit on the log scale:
+
+```{r}
+fit_log <- lm(log(Ozone) ~ Temp, data = aq)
+summary(fit_log)
+```
+
+Better — R-squared bumps up, and on the log scale a single linear term captures most of what the quadratic was doing on the original scale. The coefficient `Temp = `r round(coef(fit_log)["Temp"], 4)`` means each 1°F increase in temperature is associated with roughly a `r round(100 * (exp(coef(fit_log)["Temp"]) - 1), 1)`% increase in ozone.
+
+## Step 8 — Predictions
+
+What ozone level does the log-scale model predict for a hypothetical 90°F day?
+
+```{r}
+pred <- predict(
+  fit_log,
+  newdata = tibble::tibble(Temp = 90),
+  interval = "prediction"
+)
+exp(pred)
+```
+
+About `r round(exp(predict(fit_log, newdata = tibble::tibble(Temp = 90))), 0)` ppb, with a wide prediction interval — single-day variation is genuinely large.
+
+Visualize the fitted relationship on the original scale:
+
+```{r}
+grid <- tibble::tibble(Temp = seq(min(aq$Temp), max(aq$Temp), length.out = 100))
+grid$pred_log <- predict(fit_log, newdata = grid)
+grid$pred <- exp(grid$pred_log)
+
+ggplot(aq, aes(x = Temp, y = Ozone)) +
+  geom_point(alpha = 0.6, size = 2) +
+  geom_line(data = grid, aes(y = pred), color = "steelblue", linewidth = 1.1) +
+  labs(
+    title = "Ozone vs. temperature, with log-linear fit",
+    x = "Daily max temperature (°F)",
+    y = "Ozone (ppb)"
+  ) +
+  theme_minimal(base_size = 12)
+```
+
+## Step 9 — Write it up
+
+This is what would go in a one-paragraph "results" section of a report:
+
+> Daily ozone concentration in New York City in summer 1973 increased sharply with temperature. A simple linear regression of ozone on temperature explained roughly `r round(100 * summary(fit_linear)$r.squared, 0)`% of the variation; allowing for a quadratic term, or equivalently fitting on the log scale, raised that to about `r round(100 * summary(fit_log)$r.squared, 0)`%. The log-scale model implies each additional 1°F is associated with roughly a `r round(100 * (exp(coef(fit_log)["Temp"]) - 1), 1)`% increase in ozone, with substantial day-to-day variation around that trend. July and August had mean ozone roughly twice as high as May and September.
+
+That's a real result, expressed in plain language, with the numbers tied directly back to the analysis. If the data updated, every number would update too.
+
+## Step 10 — Make it a report
+
+Wrap the whole thing in an R Markdown file. Save the chunks above into a single `.Rmd`, add a YAML header, and knit. Now you have a self-contained, runnable, shareable analysis.
+
+````
+---
+title: "NYC Ozone vs. Temperature, Summer 1973"
+author: "Your Name"
+date: "`r '\x60r Sys.Date()\x60'`"
+output:
+  html_document:
+    toc: true
+    toc_float: true
+    code_folding: show
+---
+````
+
+## Where to go from here
+
+If you got this far, you can do real work in R. Some good next steps:
+
+- **Pick a real dataset.** Kaggle, the [tidytuesday](https://github.com/rfordatascience/tidytuesday) project, [data.gov](https://www.data.gov/), or your own work. Apply the same workflow.
+- **Read [R for Data Science](https://r4ds.hadley.nz/).** It's free online and is the standard intro to the tidyverse. It overlaps with this course but goes much deeper.
+- **Learn one new package per week for a month.** Some good first additions: `lubridate` (dates), `stringr` (strings), `forcats` (factors), `broom` (tidying model output), `gt` or `kableExtra` (publication-quality tables), `plotly` (interactive plots).
+- **Switch to Quarto.** [Quarto](https://quarto.org/) is the modern successor to R Markdown. The mental model is identical and it has nicer defaults.
+- **Try Shiny.** [Shiny](https://shiny.posit.co/) lets you turn your analysis into an interactive web app. Surprisingly easy.
+- **Practice writing functions.** Anything you find yourself doing twice, wrap in a function. Anything you do across multiple projects, put in a small package — `usethis::create_package()` is a one-liner.
+
+The R community is friendly and active — questions on [Stack Overflow](https://stackoverflow.com/questions/tagged/r) and the [Posit Community forum](https://forum.posit.co/) usually get good answers within hours, especially if you include a small reproducible example.
+
+## Thank you
+
+Thanks for working through the course. If anything was unclear, broken, or could be better, email me at **cavandonohoe@gmail.com** or open an issue on [GitHub](https://github.com/cavandonohoe/cavandonohoe.github.io). Real feedback makes this a lot better for the next person.
+
+Now go make something with it.
+
+<div class="lesson-nav">
+  <a class="nav-prev" href="rmarkdown_r.html">
+    <span class="lesson-nav-label">← Previous</span>
+    <span class="lesson-nav-title">Lesson 6: Reproducible Reports</span>
+  </a>
+  <a class="nav-next" href="learn_r.html">
+    <span class="lesson-nav-label">↑ Back to overview</span>
+    <span class="lesson-nav-title">Course Overview</span>
+  </a>
+</div>

--- a/css/learn-r.css
+++ b/css/learn-r.css
@@ -1,0 +1,222 @@
+/* Learn R lesson styling — uses site-wide CSS variables for dark mode */
+
+/* Course landing page lesson cards */
+.lesson-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1rem;
+  margin: 1.5rem 0;
+}
+
+.lesson-card {
+  border: 1px solid var(--card-border);
+  border-radius: 8px;
+  padding: 1.25rem;
+  background: var(--card-bg);
+  transition: box-shadow 0.2s ease, transform 0.2s ease;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 2px 8px var(--card-shadow);
+}
+
+.lesson-card:hover {
+  box-shadow: 0 6px 18px var(--card-shadow);
+  transform: translateY(-2px);
+}
+
+.lesson-card .lesson-number {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--muted-text);
+  margin-bottom: 0.25rem;
+}
+
+.lesson-card h3 {
+  margin: 0 0 0.5rem 0;
+  font-size: 1.15rem;
+}
+
+.lesson-card h3 a {
+  color: var(--link-color);
+  text-decoration: none;
+}
+
+.lesson-card h3 a:hover {
+  text-decoration: underline;
+}
+
+.lesson-card p {
+  font-size: 0.95rem;
+  color: var(--text-color);
+  flex-grow: 1;
+  margin-bottom: 0.5rem;
+}
+
+.lesson-card .lesson-time {
+  font-size: 0.85rem;
+  color: var(--muted-text);
+  margin-top: auto;
+}
+
+/* Callout boxes */
+.callout {
+  border-left: 4px solid var(--card-border);
+  padding: 0.75rem 1rem;
+  margin: 1rem 0;
+  background: var(--well-bg);
+  border-radius: 0 4px 4px 0;
+}
+
+.callout-title {
+  font-weight: 600;
+  margin-bottom: 0.25rem;
+}
+
+.callout-tip {
+  border-left-color: #28a745;
+}
+
+.callout-tip .callout-title { color: #28a745; }
+
+.callout-note {
+  border-left-color: var(--link-color);
+}
+
+.callout-note .callout-title { color: var(--link-color); }
+
+.callout-warning {
+  border-left-color: #f0ad4e;
+}
+
+.callout-warning .callout-title { color: #d18a1a; }
+
+[data-theme="dark"] .callout-warning .callout-title { color: #f0ad4e; }
+
+/* Exercise blocks */
+.exercise {
+  border: 1px solid var(--card-border);
+  border-left: 4px solid var(--link-color);
+  background: var(--card-bg);
+  padding: 1rem 1.25rem;
+  margin: 1.25rem 0;
+  border-radius: 0 6px 6px 0;
+}
+
+.exercise-title {
+  font-weight: 600;
+  color: var(--link-color);
+  margin-bottom: 0.5rem;
+}
+
+.exercise details {
+  margin-top: 0.75rem;
+}
+
+.exercise details > summary {
+  cursor: pointer;
+  color: var(--link-color);
+  font-weight: 500;
+  user-select: none;
+  padding: 0.25rem 0;
+}
+
+.exercise details > summary:hover {
+  text-decoration: underline;
+}
+
+.exercise details[open] > summary {
+  margin-bottom: 0.5rem;
+}
+
+/* Prev/next lesson navigation */
+.lesson-nav {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  margin: 2.5rem 0 1.5rem 0;
+  padding-top: 1.5rem;
+  border-top: 1px solid var(--card-border);
+}
+
+.lesson-nav > p {
+  display: flex;
+  width: 100%;
+  gap: 1rem;
+  margin: 0;
+}
+
+.lesson-nav a {
+  flex: 1;
+  max-width: 48%;
+  padding: 0.85rem 1rem;
+  border: 1px solid var(--card-border);
+  border-radius: 6px;
+  text-decoration: none !important;
+  color: var(--text-color) !important;
+  background: var(--card-bg);
+  transition: background 0.15s ease, border-color 0.15s ease;
+}
+
+.lesson-nav a:hover {
+  border-color: var(--link-color);
+}
+
+.lesson-nav .lesson-nav-label {
+  display: block;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--muted-text);
+  margin-bottom: 0.15rem;
+}
+
+.lesson-nav .lesson-nav-title {
+  font-weight: 500;
+}
+
+.lesson-nav .nav-prev {
+  text-align: left;
+}
+
+.lesson-nav .nav-next {
+  text-align: right;
+  margin-left: auto;
+}
+
+.lesson-nav .nav-placeholder {
+  visibility: hidden;
+}
+
+/* Course mini-progress at top of each lesson */
+.course-progress {
+  font-size: 0.9rem;
+  color: var(--muted-text);
+  margin: 0.5rem 0 1.5rem 0;
+  padding: 0.6rem 0.9rem;
+  background: var(--well-bg);
+  border-radius: 4px;
+  border-left: 3px solid var(--link-color);
+}
+
+.course-progress a {
+  color: var(--link-color);
+  text-decoration: none;
+}
+
+.course-progress a:hover {
+  text-decoration: underline;
+}
+
+/* Inline keyboard / file path styling */
+kbd {
+  display: inline-block;
+  padding: 1px 6px;
+  font-size: 0.85em;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  background: var(--code-bg);
+  color: var(--text-color);
+  border: 1px solid var(--card-border);
+  border-bottom-width: 2px;
+  border-radius: 3px;
+}

--- a/data_manipulation_r.Rmd
+++ b/data_manipulation_r.Rmd
@@ -1,6 +1,7 @@
 ---
-title: "Data Manipulation in R"
+title: "Lesson 3: Data Manipulation in R"
 author: "Cavan Donohoe"
+description: "Read data, then reshape it with the tidyverse: filter, select, mutate, group_by, summarise, and the pipe."
 output:
   html_document:
     toc: true
@@ -11,70 +12,388 @@ output:
 lang: "en"
 ---
 
+<link rel="stylesheet" href="/css/learn-r.css">
+
+<div class="course-progress">
+Lesson 3 of 7 · <a href="learn_r.html">Course overview</a>
+</div>
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(comment = "#>", message = FALSE, warning = FALSE)
+options(scipen = 999)
+```
+
 # Data Manipulation in R
 
-In this section, we will explore essential data manipulation tasks in R, including importing and exporting data, working with data frames, and performing data exploration.
+Most data analysis is the same six things, over and over: load data, filter rows, pick columns, derive new columns, group, summarise. The **tidyverse** is a family of R packages designed around these operations, and once you learn the vocabulary it becomes second-nature.
 
-## Importing and Exporting Data
+In this lesson we'll work with the built-in `mtcars` dataset (32 cars, fuel efficiency stats from a 1974 issue of *Motor Trend*). Tiny, but enough to show every concept.
 
-### Importing Data
+## Setup
 
-R provides various functions to import data from different file formats, such as CSV, Excel, and databases. Some common functions include:
+Install the tidyverse if you haven't already:
 
-- `read.csv()` for reading CSV files.
-- `read.xlsx()` for reading Excel files.
-- `readRDS()` for reading R data files.
-
-Here's an example of importing a CSV file:
-
-```R
-# Importing data from a CSV file
-data <- read.csv("data.csv")
+```{r eval=FALSE}
+install.packages("tidyverse")
 ```
 
-### Exporting Data
-To save your data or results, R offers functions like write.csv() for CSV files, write.xlsx() for Excel files, and saveRDS() for saving R data objects.
-
-```R
-# Exporting data to a CSV file
-write.csv(data, "output.csv")
-```
-
-## Data Frames and Data Exploration
-Data frames are a common data structure in R for storing tabular data. They are like spreadsheets with rows and columns, and each column can have a different data type. You can create, manipulate, and explore data frames in R.
+And load it:
 
 ```{r}
-# Creating a data frame
-df <- data.frame(
-  Name = c("Alice", "Bob", "Charlie"),
-  Age = c(25, 30, 22),
-  Score = c(95, 88, 75)
+library(dplyr)
+library(tidyr)
+library(readr)
+```
+
+We're loading three packages: `dplyr` (the manipulation verbs), `tidyr` (reshaping), and `readr` (fast CSV reading). `library(tidyverse)` would load all of these and a few more in one shot.
+
+<div class="callout callout-note">
+<div class="callout-title">📝 <code>library()</code> vs <code>::</code></div>
+You can also call any function with `package::function()` — e.g. `dplyr::filter(mtcars, mpg > 25)` — without ever calling `library()`. That's what production R code typically does, because it's explicit about where every function comes from. For learning, `library()` is fine and what most tutorials do.
+</div>
+
+## Reading data
+
+For most analyses you'll start with a CSV. `readr::read_csv()` reads a CSV into a tibble (a tidyverse-flavored data frame):
+
+```{r eval=FALSE}
+my_data <- read_csv("path/to/file.csv")
+```
+
+`read_csv()` accepts a URL too, which is great for tutorials and reproducible examples:
+
+```{r eval=FALSE}
+penguins <- read_csv(
+  "https://raw.githubusercontent.com/allisonhorst/palmerpenguins/main/inst/extdata/penguins.csv"
 )
-df
 ```
 
+For Excel files use `readxl::read_excel()`. For databases use `DBI` plus a driver package. For R's native binary format use `readRDS()` and `saveRDS()`.
 
-Data exploration involves understanding your data's characteristics, such as summary statistics, distribution, and relationships between variables. You can use functions like summary(), str(), and data visualization libraries like ggplot2 for this purpose.
-
+For this lesson we'll use the built-in `mtcars`. Let's convert it to a tibble and add a `model` column from the row names:
 
 ```{r}
-# Summary statistics
-summary(df)
-
-# Structure of the data frame
-str(df)
+cars <- mtcars |>
+  tibble::rownames_to_column("model") |>
+  tibble::as_tibble()
+cars
 ```
 
-In this section, we've covered the basics of importing and exporting data and introduced data frames and data exploration. These skills are crucial for working with real-world data and performing meaningful analyses.
+A **tibble** prints nicer than a base data frame (only the first 10 rows by default, with column types in the header) and is otherwise mostly the same thing.
 
-Feel free to practice these concepts with your own datasets to gain hands-on experience.
+## The pipe
 
+You just saw `|>`. That's R's **pipe operator**, and it's what makes tidyverse code readable. It takes the thing on its left and feeds it to the function on its right as the first argument:
 
-Free Lessons:
+```{r eval=FALSE}
+mean(c(1, 2, 3))
+# is equivalent to
+c(1, 2, 3) |> mean()
+```
 
-- [R Time Is Limited, Let's Make the Most of It](https://cavandonohoe.github.io/learn_r.html)
-- [Introduction to R](https://cavandonohoe.github.io/intro_to_r.html)
-- [Basic Operations in R](https://cavandonohoe.github.io/basic_operations_r.html)
-- [Data Manipulation](https://cavandonohoe.github.io/data_manipulation_r.html)
-- [Data Visualization](https://cavandonohoe.github.io/data_visualization_r.html)
-- [Statistics in R](https://cavandonohoe.github.io/statistics_with_r.html)
+By itself that's a wash. The win is when you chain operations:
+
+```{r eval=FALSE}
+# without the pipe — read inside-out:
+arrange(filter(select(cars, model, mpg, cyl), cyl == 4), desc(mpg))
+
+# with the pipe — read top-to-bottom:
+cars |>
+  select(model, mpg, cyl) |>
+  filter(cyl == 4) |>
+  arrange(desc(mpg))
+```
+
+The pipe version reads almost like English: "take cars, select these columns, filter to 4-cylinder cars, sort by mpg descending."
+
+<div class="callout callout-tip">
+<div class="callout-title">💡 The pipe shortcut</div>
+RStudio has a built-in shortcut for the pipe: <kbd>Cmd</kbd>/<kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>M</kbd>. Use it. You'll type the pipe thousands of times.
+
+You may also see `%>%` in older code — that's the original pipe from the `magrittr` package. They're nearly equivalent; the new built-in `|>` is the modern default.
+</div>
+
+## The five core dplyr verbs
+
+These are the verbs you'll use 95% of the time. Each takes a data frame and returns a data frame.
+
+### `filter()` — keep rows
+
+```{r}
+cars |> filter(cyl == 6)
+cars |> filter(mpg > 25, hp < 100)
+cars |> filter(cyl == 4 | cyl == 6)
+```
+
+Multiple conditions separated by commas are combined with `&` (AND).
+
+### `select()` — pick columns
+
+```{r}
+cars |> select(model, mpg, cyl)
+cars |> select(-disp, -hp)              # drop columns
+cars |> select(model, mpg:hp)           # range
+cars |> select(starts_with("d"))        # by name pattern
+```
+
+### `mutate()` — create or change columns
+
+```{r}
+cars |>
+  mutate(
+    kpl = mpg * 0.425,                  # km per liter
+    weight_lbs = wt * 1000,
+    is_efficient = mpg > 25
+  ) |>
+  select(model, mpg, kpl, weight_lbs, is_efficient)
+```
+
+`mutate()` can use any R function — including ones you write yourself.
+
+### `arrange()` — sort rows
+
+```{r}
+cars |> arrange(mpg)              # ascending
+cars |> arrange(desc(mpg))        # descending
+cars |> arrange(cyl, desc(mpg))   # multi-key
+```
+
+### `summarise()` + `group_by()` — collapse rows
+
+`summarise()` reduces a data frame to a single row. By itself it's not that interesting:
+
+```{r}
+cars |> summarise(mean_mpg = mean(mpg), n = n())
+```
+
+But pair it with `group_by()` and you have a pivot table:
+
+```{r}
+cars |>
+  group_by(cyl) |>
+  summarise(
+    n = n(),
+    mean_mpg = mean(mpg),
+    sd_mpg = sd(mpg),
+    .groups = "drop"
+  )
+```
+
+This is one of the most-used patterns in all of data analysis. "For each group, compute X."
+
+You can group by multiple variables:
+
+```{r}
+cars |>
+  group_by(cyl, am) |>     # am: 0 = automatic, 1 = manual
+  summarise(mean_mpg = mean(mpg), n = n(), .groups = "drop")
+```
+
+## A recipe-style example
+
+Suppose you want to know: **for cars with more than 100 horsepower, what's the average MPG by number of cylinders, sorted from worst to best?**
+
+```{r}
+cars |>
+  filter(hp > 100) |>
+  group_by(cyl) |>
+  summarise(
+    mean_mpg = mean(mpg),
+    n = n(),
+    .groups = "drop"
+  ) |>
+  arrange(mean_mpg)
+```
+
+That's the whole answer in 6 lines. No loops, no manual indexing, no temp variables. This is why people like the tidyverse.
+
+## A few more useful verbs
+
+### `count()` — quick frequency table
+
+```{r}
+cars |> count(cyl)
+cars |> count(cyl, sort = TRUE)
+cars |> count(cyl, am)
+```
+
+### `case_when()` — multi-branch `if`
+
+Inside `mutate()`, `case_when()` is the right tool for "if-elseif-else" logic. Each `~` line is "condition ~ value":
+
+```{r}
+cars |>
+  mutate(
+    mpg_class = case_when(
+      mpg < 15  ~ "thirsty",
+      mpg < 22  ~ "average",
+      mpg < 28  ~ "good",
+      TRUE      ~ "great"
+    )
+  ) |>
+  count(mpg_class)
+```
+
+The final `TRUE ~ ...` is the catch-all "else."
+
+### `slice_*()` — top/bottom/random rows
+
+```{r}
+cars |> slice_max(mpg, n = 3)         # 3 highest mpg
+cars |> slice_min(hp, n = 3)          # 3 lowest hp
+cars |> slice_sample(n = 3)           # 3 random rows
+```
+
+### Joining tables
+
+When you have two related tables, `*_join()` combines them on a shared key:
+
+```{r}
+classes <- tibble::tibble(
+  cyl = c(4, 6, 8),
+  class = c("compact", "midsize", "muscle")
+)
+
+cars |>
+  select(model, cyl, mpg) |>
+  left_join(classes, by = "cyl") |>
+  head()
+```
+
+`left_join()` keeps every row from the left table and pulls in matching rows from the right. There's also `inner_join()`, `right_join()`, and `full_join()` for different behaviors when keys don't match on both sides.
+
+## Reshaping with `tidyr`
+
+Sometimes data comes in **wide** format (one column per category) when you need it **long** (one row per observation), or vice versa. `tidyr` has `pivot_longer()` and `pivot_wider()` for that.
+
+```{r}
+wide <- tibble::tibble(
+  city = c("LA", "NYC", "Chicago"),
+  jan = c(58, 32, 25),
+  jul = c(83, 78, 76)
+)
+wide
+
+long <- wide |>
+  pivot_longer(cols = c(jan, jul), names_to = "month", values_to = "temp_f")
+long
+
+long |> pivot_wider(names_from = month, values_from = temp_f)
+```
+
+`pivot_longer()` is the one you'll reach for most — most analysis, plotting, and modeling functions expect long data.
+
+## Putting it together
+
+Here's a more realistic mini-analysis. We'll classify cars by efficiency, count how many fall into each class by transmission type, and report it as a clean wide table.
+
+```{r}
+cars |>
+  mutate(
+    transmission = if_else(am == 1, "manual", "automatic"),
+    efficiency = case_when(
+      mpg < 18 ~ "low",
+      mpg < 24 ~ "medium",
+      TRUE     ~ "high"
+    )
+  ) |>
+  count(transmission, efficiency) |>
+  pivot_wider(names_from = efficiency, values_from = n, values_fill = 0)
+```
+
+The whole pipeline is one connected thought, and you can comment out any line to see the intermediate result.
+
+<div class="exercise">
+<div class="exercise-title">✏️ Exercise 3.1 — Filter and sort</div>
+
+Using `cars`, find the 5 cars with the worst MPG. Show only the `model`, `mpg`, and `hp` columns.
+
+<details>
+<summary>Show solution</summary>
+
+```{r}
+cars |>
+  arrange(mpg) |>
+  select(model, mpg, hp) |>
+  head(5)
+```
+
+Or with `slice_min`:
+
+```{r}
+cars |>
+  slice_min(mpg, n = 5) |>
+  select(model, mpg, hp)
+```
+
+</details>
+</div>
+
+<div class="exercise">
+<div class="exercise-title">✏️ Exercise 3.2 — Group and summarise</div>
+
+For each unique combination of cylinders (`cyl`) and gears (`gear`), compute:
+
+- the number of cars (`n`)
+- the mean MPG
+- the mean horsepower
+
+Sort the result with the highest mean MPG first.
+
+<details>
+<summary>Show solution</summary>
+
+```{r}
+cars |>
+  group_by(cyl, gear) |>
+  summarise(
+    n = n(),
+    mean_mpg = mean(mpg),
+    mean_hp = mean(hp),
+    .groups = "drop"
+  ) |>
+  arrange(desc(mean_mpg))
+```
+
+</details>
+</div>
+
+<div class="exercise">
+<div class="exercise-title">✏️ Exercise 3.3 — Build a feature</div>
+
+Add two new columns to `cars`:
+
+1. `power_to_weight` — horsepower per 1000 lbs (i.e. `hp / wt`).
+2. `category` — `"sporty"` if `power_to_weight > 50`, otherwise `"normal"`.
+
+Then count the cars in each category.
+
+<details>
+<summary>Show solution</summary>
+
+```{r}
+cars |>
+  mutate(
+    power_to_weight = hp / wt,
+    category = if_else(power_to_weight > 50, "sporty", "normal")
+  ) |>
+  count(category)
+```
+
+</details>
+</div>
+
+## What's next
+
+You now have the toolkit to load, clean, and summarise data — easily 60% of any real analysis. Next up: making the results visible. Lesson 4 is about plotting with `ggplot2`, which pairs cleanly with everything you just learned.
+
+<div class="lesson-nav">
+  <a class="nav-prev" href="basic_operations_r.html">
+    <span class="lesson-nav-label">← Previous</span>
+    <span class="lesson-nav-title">Lesson 2: Basic Operations</span>
+  </a>
+  <a class="nav-next" href="data_visualization_r.html">
+    <span class="lesson-nav-label">Next →</span>
+    <span class="lesson-nav-title">Lesson 4: Data Visualization</span>
+  </a>
+</div>

--- a/data_visualization_r.Rmd
+++ b/data_visualization_r.Rmd
@@ -1,6 +1,7 @@
 ---
-title: "Data Visualization in R"
+title: "Lesson 4: Data Visualization in R"
 author: "Cavan Donohoe"
+description: "The grammar of graphics with ggplot2: geoms, aesthetics, facets, themes, and saving plots."
 output:
   html_document:
     toc: true
@@ -11,68 +12,353 @@ output:
 lang: "en"
 ---
 
+<link rel="stylesheet" href="/css/learn-r.css">
+
+<div class="course-progress">
+Lesson 4 of 7 · <a href="learn_r.html">Course overview</a>
+</div>
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(
+  comment = "#>",
+  message = FALSE,
+  warning = FALSE,
+  fig.width = 6.5,
+  fig.height = 4.2,
+  dpi = 100
+)
+options(scipen = 999)
+```
+
 # Data Visualization in R
 
-In this section, we will explore the exciting world of data visualization in R. We'll cover creating basic plots, customizing plots, and diving into advanced visualization techniques using the ggplot2 package.
+Plotting in R is excellent. You've already seen `plot()` — it works, but the real toolkit is **ggplot2**. It's based on a "grammar of graphics" that, once it clicks, lets you describe almost any plot in a handful of lines.
 
-## Creating Basic Plots
+This lesson covers the ggplot2 grammar, the most common geoms, faceting, themes, and how to save plots.
 
-R offers a variety of functions for creating basic plots, including:
-
-- `plot()`: For creating scatterplots and line plots.
-- `hist()`: For creating histograms.
-- `barplot()`: For creating bar charts.
-- `boxplot()`: For creating box plots.
-
-Here's an example of creating a simple scatterplot:
-
-```R
-# Creating a scatterplot
-x <- c(1, 2, 3, 4, 5)
-y <- c(10, 15, 7, 20, 12)
-
-plot(x, y, type = "p", main = "Scatterplot Example", xlab = "X-axis", ylab = "Y-axis")
-```
-
-## Customizing Plots
-Customizing plots allows you to make them more informative and visually appealing. You can customize various aspects of your plots, including titles, labels, colors, and more. Here's an example:
+## Setup
 
 ```{r}
-data_example <- data.frame(
-  x = c(1, 2, 3, 4, 5, 6),
-  y = c(2, 3.5, 2, 4, 4.5, 7)
+library(ggplot2)
+library(dplyr)
+
+cars <- mtcars |>
+  tibble::rownames_to_column("model") |>
+  tibble::as_tibble() |>
+  mutate(
+    cyl = factor(cyl),
+    transmission = if_else(am == 1, "manual", "automatic")
+  )
+```
+
+## The ggplot2 grammar
+
+Every ggplot2 plot has three required pieces:
+
+1. **Data** — the data frame you're plotting.
+2. **Aesthetics** (`aes()`) — which columns map to which visual properties (x, y, color, size, shape).
+3. **Geoms** — the geometric shapes to draw (points, bars, lines, boxes, ...).
+
+The pattern:
+
+```r
+ggplot(data, aes(x = ..., y = ..., color = ...)) +
+  geom_*()
+```
+
+You add layers with `+`. Yes, `+` (not the pipe). Inside a `ggplot()` call you `+`, between data steps you `|>`. It's a mild gotcha and you'll get it wrong a lot at first.
+
+## A first plot
+
+```{r}
+ggplot(cars, aes(x = wt, y = mpg)) +
+  geom_point()
+```
+
+That's the whole plot: data (`cars`), aesthetics (`wt` on x, `mpg` on y), one geom (`geom_point` for a scatterplot).
+
+Now let's add color, size, and labels:
+
+```{r}
+ggplot(cars, aes(x = wt, y = mpg, color = cyl, size = hp)) +
+  geom_point(alpha = 0.8) +
+  labs(
+    title = "Heavier, more powerful cars get worse mileage",
+    subtitle = "Each point is a 1974 car model",
+    x = "Weight (1000 lbs)",
+    y = "Miles per gallon",
+    color = "Cylinders",
+    size = "Horsepower"
+  )
+```
+
+Notice three things:
+
+- `color = cyl` and `size = hp` are inside `aes()` because they map to data columns.
+- `alpha = 0.8` is outside `aes()` because it's a fixed value (every point gets the same alpha), not a mapping.
+- `labs()` controls every text label on the plot at once.
+
+## The most useful geoms
+
+### `geom_point()` — scatterplots
+
+Shown above. Add `geom_smooth()` to overlay a regression line:
+
+```{r}
+ggplot(cars, aes(x = wt, y = mpg)) +
+  geom_point() +
+  geom_smooth(method = "lm", se = TRUE)
+```
+
+`method = "lm"` is a straight line; the default `"loess"` is a smooth curve.
+
+### `geom_line()` — connect points by some ordering
+
+```{r}
+year_data <- tibble::tibble(
+  year = 2015:2024,
+  sales = c(100, 108, 121, 119, 130, 145, 160, 158, 172, 185)
 )
 
-# Customizing a plot
-plot(data_example$x, data_example$y, type = "p", main = "Customized Scatterplot",
-     xlab = "X-axis", ylab = "Y-axis", col = "blue", pch = 19)
+ggplot(year_data, aes(x = year, y = sales)) +
+  geom_line(linewidth = 1.1, color = "steelblue") +
+  geom_point(size = 2.5, color = "steelblue") +
+  labs(title = "Sales over time", x = NULL, y = "Sales (units)")
 ```
 
-## Advanced Visualization with ggplot2
-The ggplot2 package is a powerful and versatile tool for creating a wide range of customized and complex visualizations. It follows a grammar of graphics approach, making it intuitive and flexible. Here's a basic example using ggplot2:
+### `geom_bar()` and `geom_col()` — bar charts
 
-```{r message=FALSE}
-# Load the ggplot2 library
+`geom_bar()` counts rows itself. `geom_col()` uses the y-value you give it.
 
-# Create a ggplot scatterplot
-ggplot2::ggplot(data = data_example, ggplot2::aes(x = x, y = y)) +
-  ggplot2::geom_point(size = 3, color = "red") +
-  ggplot2::labs(title = "ggplot2 Scatterplot", x = "X-axis", y = "Y-axis")
+```{r}
+ggplot(cars, aes(x = cyl)) +
+  geom_bar(fill = "steelblue") +
+  labs(title = "How many of each cylinder count?", x = "Cylinders", y = "Count")
 ```
 
-In this section, we've covered the fundamentals of data visualization in R, including creating basic plots, customizing them to meet your needs, and introducing you to the power of ggplot2 for advanced visualization. Data visualization is a crucial skill for exploring and communicating insights from your data effectively.
+```{r}
+cars |>
+  group_by(cyl) |>
+  summarise(mean_mpg = mean(mpg), .groups = "drop") |>
+  ggplot(aes(x = cyl, y = mean_mpg, fill = cyl)) +
+  geom_col() +
+  geom_text(aes(label = round(mean_mpg, 1)), vjust = -0.4) +
+  labs(title = "Average MPG by cylinder count", x = "Cylinders", y = "Mean MPG") +
+  theme(legend.position = "none")
+```
 
-Feel free to experiment with different plot types and customization options to enhance your data visualization skills.
+Notice we pipe a `dplyr` summary directly into `ggplot()`. This is the standard tidyverse workflow.
 
+### `geom_histogram()` and `geom_density()` — distributions
 
+```{r}
+ggplot(cars, aes(x = mpg)) +
+  geom_histogram(bins = 12, fill = "steelblue", color = "white") +
+  labs(title = "Distribution of MPG across all cars", x = "MPG", y = "Count")
+```
 
+```{r}
+ggplot(cars, aes(x = mpg, fill = transmission)) +
+  geom_density(alpha = 0.5) +
+  labs(title = "MPG by transmission type", x = "MPG", y = "Density")
+```
 
-Free Lessons:
+### `geom_boxplot()` — distributions by group
 
-- [R Time Is Limited, Let's Make the Most of It](https://cavandonohoe.github.io/learn_r.html)
-- [Introduction to R](https://cavandonohoe.github.io/intro_to_r.html)
-- [Basic Operations in R](https://cavandonohoe.github.io/basic_operations_r.html)
-- [Data Manipulation](https://cavandonohoe.github.io/data_manipulation_r.html)
-- [Data Visualization](https://cavandonohoe.github.io/data_visualization_r.html)
-- [Statistics in R](https://cavandonohoe.github.io/statistics_with_r.html)
+```{r}
+ggplot(cars, aes(x = cyl, y = mpg, fill = cyl)) +
+  geom_boxplot() +
+  labs(title = "MPG by cylinder count", x = "Cylinders", y = "MPG") +
+  theme(legend.position = "none")
+```
 
+## Faceting — small multiples
+
+`facet_wrap()` and `facet_grid()` let you split a plot into a grid of subplots, one per category. Often more informative than mapping a category to color.
+
+```{r}
+ggplot(cars, aes(x = wt, y = mpg)) +
+  geom_point() +
+  geom_smooth(method = "lm", se = FALSE) +
+  facet_wrap(~ cyl, labeller = label_both) +
+  labs(title = "Weight vs. MPG by cylinder count")
+```
+
+`facet_grid()` does a 2D grid of categories:
+
+```{r}
+ggplot(cars, aes(x = wt, y = mpg)) +
+  geom_point() +
+  facet_grid(transmission ~ cyl, labeller = label_both) +
+  labs(title = "Weight vs. MPG by transmission and cylinder count")
+```
+
+## Scales — controlling axes and color
+
+Scales control how data values map to visual properties. Common ones:
+
+```{r}
+ggplot(cars, aes(x = wt, y = mpg, color = hp)) +
+  geom_point(size = 3) +
+  scale_color_viridis_c(option = "plasma") +
+  scale_x_continuous(limits = c(1, 6), breaks = 1:6) +
+  scale_y_continuous(name = "Miles per gallon") +
+  labs(title = "Weight vs. MPG, colored by horsepower")
+```
+
+A few worth knowing:
+
+- `scale_*_continuous()` — for numeric axes; sets limits, breaks, labels.
+- `scale_*_log10()` — log axis (useful when data spans orders of magnitude).
+- `scale_color_viridis_*()` / `scale_fill_viridis_*()` — perceptually uniform, color-blind-friendly palettes. Use these.
+- `scale_color_manual()` — assign specific colors to specific levels.
+
+## Themes — controlling the non-data ink
+
+Themes change how the plot *looks* — gridlines, fonts, backgrounds. ggplot2 ships with several:
+
+```{r}
+p <- ggplot(cars, aes(x = wt, y = mpg, color = cyl)) +
+  geom_point(size = 3) +
+  labs(title = "Weight vs. MPG", x = "Weight", y = "MPG")
+
+p + theme_minimal()
+```
+
+```{r}
+p + theme_classic()
+```
+
+You can also tweak individual theme elements:
+
+```{r}
+p +
+  theme_minimal(base_size = 13) +
+  theme(
+    plot.title = element_text(face = "bold", size = 16),
+    legend.position = "bottom",
+    panel.grid.minor = element_blank()
+  )
+```
+
+Setting a theme for the whole session:
+
+```{r eval=FALSE}
+theme_set(theme_minimal(base_size = 13))
+```
+
+## Saving plots
+
+`ggsave()` saves the most recent plot — or one you pass to it — as a file:
+
+```{r eval=FALSE}
+my_plot <- ggplot(cars, aes(x = wt, y = mpg)) + geom_point()
+
+ggsave("my_plot.png", my_plot, width = 6, height = 4, dpi = 300)
+ggsave("my_plot.pdf", my_plot, width = 6, height = 4)
+```
+
+`ggsave()` infers the format from the file extension. Width and height are in inches by default.
+
+## Putting it together
+
+Let's build a single, polished figure that summarises something interesting from the data: how MPG depends on weight, broken out by cylinder count, with a fitted line for each group.
+
+```{r fig.height=5}
+ggplot(cars, aes(x = wt, y = mpg, color = cyl)) +
+  geom_point(size = 3, alpha = 0.85) +
+  geom_smooth(method = "lm", se = FALSE, linewidth = 0.9) +
+  scale_color_viridis_d(option = "viridis", end = 0.85) +
+  labs(
+    title = "Heavier cars get worse mileage — but cylinder count matters too",
+    subtitle = "Each point is a 1974 car model from the mtcars dataset",
+    x = "Weight (1000 lbs)",
+    y = "Miles per gallon",
+    color = "Cylinders",
+    caption = "Data: Henderson & Velleman (1981). Building multiple regression models interactively."
+  ) +
+  theme_minimal(base_size = 13) +
+  theme(
+    plot.title = element_text(face = "bold"),
+    plot.subtitle = element_text(color = "grey40"),
+    plot.caption = element_text(color = "grey50", hjust = 0),
+    legend.position = "bottom",
+    panel.grid.minor = element_blank()
+  )
+```
+
+That's a publication-quality plot in about 20 lines.
+
+<div class="exercise">
+<div class="exercise-title">✏️ Exercise 4.1 — Your first ggplot</div>
+
+Make a scatterplot of `hp` (x) versus `mpg` (y) from `cars`, with points colored by `cyl`. Add a title.
+
+<details>
+<summary>Show solution</summary>
+
+```{r}
+ggplot(cars, aes(x = hp, y = mpg, color = cyl)) +
+  geom_point(size = 3) +
+  labs(title = "Horsepower vs. MPG", x = "Horsepower", y = "MPG", color = "Cylinders")
+```
+
+</details>
+</div>
+
+<div class="exercise">
+<div class="exercise-title">✏️ Exercise 4.2 — Bars from a summary</div>
+
+For each transmission type (`automatic` / `manual`), compute the mean MPG. Plot it as a bar chart with the bar height equal to the mean.
+
+<details>
+<summary>Show solution</summary>
+
+```{r}
+cars |>
+  group_by(transmission) |>
+  summarise(mean_mpg = mean(mpg), .groups = "drop") |>
+  ggplot(aes(x = transmission, y = mean_mpg, fill = transmission)) +
+  geom_col(width = 0.6) +
+  geom_text(aes(label = round(mean_mpg, 1)), vjust = -0.4) +
+  labs(title = "Mean MPG by transmission type", x = NULL, y = "Mean MPG") +
+  theme_minimal() +
+  theme(legend.position = "none")
+```
+
+</details>
+</div>
+
+<div class="exercise">
+<div class="exercise-title">✏️ Exercise 4.3 — Faceting</div>
+
+Make a scatterplot of `wt` vs. `mpg`, with one panel per cylinder count, and a linear fit line in each panel.
+
+<details>
+<summary>Show solution</summary>
+
+```{r}
+ggplot(cars, aes(x = wt, y = mpg)) +
+  geom_point() +
+  geom_smooth(method = "lm", se = FALSE) +
+  facet_wrap(~ cyl, labeller = label_both) +
+  theme_minimal()
+```
+
+</details>
+</div>
+
+## What's next
+
+You can now turn a data frame into a clear, attractive plot. Combined with Lesson 3, you've got a real "explore the data" workflow. Lesson 5 brings in actual statistics — t-tests, correlation, and regression — so you can quantify what your plots are showing you.
+
+<div class="lesson-nav">
+  <a class="nav-prev" href="data_manipulation_r.html">
+    <span class="lesson-nav-label">← Previous</span>
+    <span class="lesson-nav-title">Lesson 3: Data Manipulation</span>
+  </a>
+  <a class="nav-next" href="statistics_with_r.html">
+    <span class="lesson-nav-label">Next →</span>
+    <span class="lesson-nav-title">Lesson 5: Statistics with R</span>
+  </a>
+</div>

--- a/intro_to_r.Rmd
+++ b/intro_to_r.Rmd
@@ -1,6 +1,7 @@
 ---
-title: "Introduction to R"
+title: "Lesson 1: Introduction to R"
 author: "Cavan Donohoe"
+description: "What R is, how to install it, the RStudio tour, your first script, and how to install packages."
 output:
   html_document:
     toc: true
@@ -11,61 +12,228 @@ output:
 lang: "en"
 ---
 
+<link rel="stylesheet" href="/css/learn-r.css">
+
+<div class="course-progress">
+Lesson 1 of 7 · <a href="learn_r.html">Course overview</a>
+</div>
+
 # Introduction to R
 
-In this section, we'll cover the basics of R, including what R is, how to install it, and an overview of the RStudio interface.
+R is a free programming language built specifically for working with data. Pretty much every statistical method you've heard of has an R implementation, and a lot of them were *first* implemented in R. The graphics are excellent, the package ecosystem is huge, and you can use it for everything from a one-off plot to a peer-reviewed publication.
+
+This lesson covers four things:
+
+1. What R actually is (and what it isn't).
+2. Installing R and RStudio.
+3. A quick tour of the RStudio interface.
+4. Writing and running your first script.
 
 ## What is R?
 
-R is a powerful and open-source programming language and software environment for statistical computing and graphics. It provides a wide range of statistical and graphical techniques and is widely used in data analysis, data visualization, and statistical modeling.
+R is two things at once: a **programming language** and an **interactive environment**. You can type `2 + 2` at the prompt and get `4` back, just like a calculator. Or you can write a 500-line script that loads a CSV, fits a model, and produces a PDF report.
+
+R was created in the early 1990s by statisticians at the University of Auckland, and it shows: the language has built-in support for vectors, missing values, factors, and other things that statisticians care about. It's *very* good at "load a table, do something to every row, summarise the result." It's less great at writing a video game.
+
+R is open source. Anyone can use it, anyone can contribute packages, and the [Comprehensive R Archive Network (CRAN)](https://cran.r-project.org/) hosts more than 20,000 add-on packages — for everything from genomics to finance to natural language processing.
+
+<div class="callout callout-note">
+<div class="callout-title">📝 R vs. Python</div>
+You'll hear "R or Python?" a lot. Honest answer: both are fine, you can do almost anything in either, and most working data scientists use both. R has the edge for statistics, reporting, and visualization out of the box. Python has the edge for general programming, web apps, and most of modern machine learning. If you already know Python, R will feel quirky for a week and then second-nature.
+</div>
 
 ## Installing R and RStudio
 
-Before we can start using R, we need to install it and its integrated development environment, RStudio. Here are the steps to get you started:
+You need two things: **R** itself (the engine) and **RStudio** (a much nicer place to write R code than the bare R console).
 
-### Step 1: Installing R
+### Step 1: Install R
 
-1. Visit the Comprehensive R Archive Network (CRAN) website at [https://cran.r-project.org/mirrors.html](https://cran.r-project.org/mirrors.html).
+1. Go to [https://cran.r-project.org/](https://cran.r-project.org/) and click the link for your operating system (Windows, macOS, or Linux).
+2. Download the latest base R installer.
+3. Run the installer with the default options — for most users you don't need to change anything.
 
-2. Choose a CRAN mirror near your location to download R.
+### Step 2: Install RStudio Desktop
 
-3. Download and install R for your operating system (Windows, macOS, or Linux).
+1. Go to [https://posit.co/download/rstudio-desktop/](https://posit.co/download/rstudio-desktop/).
+2. Download the **free** RStudio Desktop installer for your OS.
+3. Run the installer. RStudio will find your R installation automatically.
 
-### Step 2: Installing RStudio
+When you open RStudio for the first time, you should see a window with several panes. If you see a `>` prompt in one of them, you're good to go.
 
-1. Visit the RStudio download page at [https://www.rstudio.com/products/rstudio/download/](https://www.rstudio.com/products/rstudio/download/).
+<div class="callout callout-warning">
+<div class="callout-title">⚠️ One install, not two languages</div>
+RStudio is just an editor — it runs R for you. If you uninstall R, RStudio breaks. If you install a new version of R, RStudio will pick it up automatically.
+</div>
 
-2. Download the free RStudio Desktop version that corresponds to your operating system.
+## A tour of RStudio
 
-3. Install RStudio by following the installation instructions for your operating system.
+By default RStudio shows four panes:
 
-Once you've completed these steps, you'll have R and RStudio installed and ready to use.
+- **Source / Script editor** (top-left): where you write R scripts and R Markdown documents. This is where you'll spend most of your time.
+- **Console** (bottom-left): the live R session. Anything you run from the script gets sent here. You can also type directly into the console for one-off commands.
+- **Environment / History** (top-right): every variable, dataset, or function you've created in the current session shows up here. Great for sanity-checking what's loaded.
+- **Files / Plots / Packages / Help / Viewer** (bottom-right): file browser, plot output, installed packages, the help system, and the viewer for HTML output (like rendered R Markdown).
 
-## RStudio Interface Overview
+A few keyboard shortcuts that pay for themselves immediately:
 
-RStudio is an integrated development environment (IDE) that makes working with R easier and more efficient. Let's take a quick tour of the RStudio interface:
+| Shortcut | What it does |
+|----------|--------------|
+| <kbd>Cmd</kbd>/<kbd>Ctrl</kbd> + <kbd>Enter</kbd> | Run the current line (or selection) from the script |
+| <kbd>Cmd</kbd>/<kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>N</kbd> | New R script |
+| <kbd>Cmd</kbd>/<kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>M</kbd> | Insert the pipe operator (`|>`) |
+| <kbd>Alt</kbd> + <kbd>-</kbd> | Insert the assignment operator (`<-`) |
+| <kbd>Cmd</kbd>/<kbd>Ctrl</kbd> + <kbd>L</kbd> | Clear the console |
 
-- **Script Editor**: This is where you can write and execute R code. You can create new scripts or open existing ones.
+## Your first R script
 
-- **Console**: The R console allows you to interactively execute R commands and see the results immediately. It's great for testing small code snippets.
+Let's actually run some R. In RStudio, hit <kbd>Cmd</kbd>/<kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>N</kbd> to open a new script. Type the following (don't paste — really type it):
 
-- **Environment Pane**: Displays information about the objects (variables, data frames, functions, etc.) in your current R session.
+```{r}
+greeting <- "Hello, R!"
+greeting
+2 + 2
+sqrt(144)
+```
 
-- **Files, Plots, Packages, Help**: These panes provide access to your project files, plots, installed packages, and documentation.
+Place your cursor on the first line and hit <kbd>Cmd</kbd>/<kbd>Ctrl</kbd> + <kbd>Enter</kbd>. The line gets sent to the console. Do it for each line. You should see:
 
-- **Toolbar**: Contains shortcuts for common actions like running code, saving scripts, and more.
+- `greeting` was assigned the value `"Hello, R!"` and now appears in the Environment pane.
+- `2 + 2` prints `4`.
+- `sqrt(144)` prints `12`.
 
-- **Markdown and Plots Tabs**: Use these tabs to view rendered R Markdown documents and plots generated within your R Markdown document.
+A few things to notice:
 
-That's it for our brief introduction to R and RStudio! Now that you have them installed and have a basic understanding of the interface, you're ready to start exploring R and writing your first R code.
+- `<-` is R's assignment operator. You can use `=` too, but `<-` is the convention. Use the <kbd>Alt</kbd> + <kbd>-</kbd> shortcut.
+- Anything after `#` on a line is a comment — R ignores it.
+- Functions are called with parentheses: `sqrt(144)`, `mean(c(1, 2, 3))`. Without the parentheses, R prints the function's source code instead of running it.
 
+Save the script with <kbd>Cmd</kbd>/<kbd>Ctrl</kbd> + <kbd>S</kbd>. Call it `hello.R`. Now you have your first R script.
 
+## Installing and using packages
 
-Free Lessons:
+R's superpower is its packages. A **package** is a bundle of functions and data someone else wrote. To use one, you install it once and then load it whenever you need it.
 
-- [R Time Is Limited, Let's Make the Most of It](https://cavandonohoe.github.io/learn_r.html)
-- [Introduction to R](https://cavandonohoe.github.io/intro_to_r.html)
-- [Basic Operations in R](https://cavandonohoe.github.io/basic_operations_r.html)
-- [Data Manipulation](https://cavandonohoe.github.io/data_manipulation_r.html)
-- [Data Visualization](https://cavandonohoe.github.io/data_visualization_r.html)
-- [Statistics in R](https://cavandonohoe.github.io/statistics_with_r.html)
+```{r eval=FALSE}
+install.packages("dplyr")
+library(dplyr)
+```
+
+- `install.packages("dplyr")` downloads and installs the `dplyr` package from CRAN. You only need to do this once per machine.
+- `library(dplyr)` loads it into your current session, so its functions are available. You do this every session.
+
+You can also call a function from a package without loading the whole package by using `::`:
+
+```{r eval=FALSE}
+dplyr::filter(mtcars, mpg > 25)
+```
+
+This is helpful when you only need one function or want to be explicit about where it came from. We'll use it occasionally throughout the course.
+
+The packages we'll use the most:
+
+- `dplyr` and `tidyr` — data manipulation
+- `ggplot2` — plotting
+- `readr` — reading CSVs
+- `rmarkdown` and `knitr` — reproducible reports
+
+You can install them all at once with the `tidyverse` umbrella package:
+
+```{r eval=FALSE}
+install.packages("tidyverse")
+```
+
+## Getting help
+
+When (not if) you forget how a function works, R has built-in help. Three ways to get it:
+
+```{r eval=FALSE}
+?mean
+help("mean")
+example("mean")
+```
+
+The help page opens in the bottom-right pane. Every help page has the same sections: **Description**, **Usage**, **Arguments**, **Value**, **Examples**. The Examples section is gold — copy them, run them, modify them.
+
+If you don't even know the name of the function you want, `??` does a fuzzy search across all installed packages:
+
+```{r eval=FALSE}
+??"linear regression"
+```
+
+And of course, [Stack Overflow](https://stackoverflow.com/questions/tagged/r), the [Posit Community forum](https://forum.posit.co/), and now LLMs are all good for "how do I…" questions.
+
+## Putting it together
+
+Here's a tiny script that uses everything you just learned: a built-in dataset (`mtcars` — fuel efficiency for 32 cars from 1974), a function call, and a quick plot.
+
+```{r intro-mtcars-plot, fig.width=6, fig.height=4}
+head(mtcars)
+mean(mtcars$mpg)
+plot(mtcars$wt, mtcars$mpg,
+  main = "Heavier cars get worse gas mileage",
+  xlab = "Weight (1000 lbs)",
+  ylab = "Miles per gallon")
+```
+
+If you typed that in and got a similar plot back, you're in business.
+
+<div class="exercise">
+<div class="exercise-title">✏️ Exercise 1.1 — Your first script</div>
+
+Open a new R script in RStudio and write code that:
+
+1. Stores your name in a variable called `me`.
+2. Stores your age (or guess, doesn't matter) in a variable called `age`.
+3. Prints both, plus the value of `age * 365` (your age in days, roughly).
+
+<details>
+<summary>Show solution</summary>
+
+```{r}
+me <- "Cavan"
+age <- 30
+me
+age
+age * 365
+```
+
+</details>
+</div>
+
+<div class="exercise">
+<div class="exercise-title">✏️ Exercise 1.2 — Help yourself</div>
+
+R has a function called `seq()` that you've never seen before. Without searching the web, figure out what it does and use it to generate the numbers from 0 to 1 in steps of 0.1.
+
+<details>
+<summary>Show solution</summary>
+
+Run `?seq` to open the help page. The relevant arguments are `from`, `to`, and `by`:
+
+```{r}
+seq(from = 0, to = 1, by = 0.1)
+```
+
+You can also write it more compactly — R uses positional arguments:
+
+```{r}
+seq(0, 1, 0.1)
+```
+
+</details>
+</div>
+
+## What's next
+
+You can now run R, you have RStudio set up, and you know how to install packages and ask R for help. That's the whole runway. Next up: actually doing things *with* R.
+
+<div class="lesson-nav">
+  <a class="nav-prev" href="learn_r.html">
+    <span class="lesson-nav-label">← Course overview</span>
+    <span class="lesson-nav-title">Learn R Mini-Course</span>
+  </a>
+  <a class="nav-next" href="basic_operations_r.html">
+    <span class="lesson-nav-label">Next →</span>
+    <span class="lesson-nav-title">Lesson 2: Basic Operations</span>
+  </a>
+</div>

--- a/learn_r.Rmd
+++ b/learn_r.Rmd
@@ -1,6 +1,7 @@
 ---
-title: "R Time Is Limited, Let's Make the Most of It"
+title: "Learn R: A Hands-On Mini-Course"
 author: "Cavan Donohoe"
+description: "A free, hands-on introduction to R — from your first variable to a real end-to-end data analysis. Seven short lessons with worked examples and exercises."
 output:
   html_document:
     toc: true
@@ -11,72 +12,111 @@ output:
 lang: "en"
 ---
 
-Welcome to the "R Time Is Limited, Let's Make the Most of It" class! In this course, you will learn the basics of R programming and data analysis. R is a powerful and versatile programming language for statistical analysis, data visualization, and more.
+<link rel="stylesheet" href="/css/learn-r.css">
 
-## Course Objectives
+# Learn R: A Hands-On Mini-Course
 
-In this course, you will:
+R is a free, open-source language built for working with data. It's how a lot of statistics, analytics, and reproducible research actually gets done — at universities, in clinical trials, in finance, in sports analytics, everywhere. If you can get comfortable with the basics, you can do real work with it within a weekend.
 
-1. Learn the fundamentals of R programming.
-2. Explore data manipulation and analysis.
-3. Create informative data visualizations.
-4. Gain practical experience through hands-on exercises.
+This course is short, opinionated, and built around runnable examples. Every lesson ends with exercises (with hidden solutions) so you can practice as you go. You don't need a math background. You don't need a programming background. You just need to be willing to try things.
 
-## Getting Started
+## What you'll be able to do by the end
 
-Before we dive into the world of R, make sure you have R and RStudio installed on your computer. You can download them from the following links:
+By the end of the course you'll be able to:
 
-- [R](https://cran.r-project.org/mirrors.html)
-- [RStudio](https://www.rstudio.com/products/rstudio/download/)
+- Read a CSV (or download one from the web) into R
+- Clean and reshape it with the [tidyverse](https://www.tidyverse.org/) (`dplyr`, `tidyr`)
+- Make a clean, readable plot with `ggplot2`
+- Run basic statistics — means, t-tests, linear regression — and actually interpret what they say
+- Wrap the whole thing in an R Markdown report that someone else can rerun
 
-## What You Will Need
+The capstone lesson walks through a full mini-project: load a built-in dataset, explore it, model it, and write up the results.
 
-- A computer with R and RStudio installed.
-- Curiosity and enthusiasm to learn!
+## The lessons
 
-## Course Outline
+<div class="lesson-grid">
 
-1. **Introduction to R**
-   - What is R?
-   - Installing R and RStudio.
-   - RStudio interface overview.
+<div class="lesson-card">
+  <div class="lesson-number">Lesson 1</div>
+  <h3><a href="intro_to_r.html">Introduction to R</a></h3>
+  <p>What R is, how to install it, the RStudio tour, your first script, and how to install packages.</p>
+  <div class="lesson-time">~15 min</div>
+</div>
 
-2. **Basic Operations in R**
-   - Variables and data types.
-   - Arithmetic operations.
-   - Working with vectors and matrices.
+<div class="lesson-card">
+  <div class="lesson-number">Lesson 2</div>
+  <h3><a href="basic_operations_r.html">Basic Operations</a></h3>
+  <p>Variables, data types, vectors, comparisons, control flow, and writing your first function.</p>
+  <div class="lesson-time">~25 min</div>
+</div>
 
-3. **Data Manipulation**
-   - Importing and exporting data.
-   - Data frames and data exploration.
+<div class="lesson-card">
+  <div class="lesson-number">Lesson 3</div>
+  <h3><a href="data_manipulation_r.html">Data Manipulation</a></h3>
+  <p>Read data, then reshape it with the tidyverse: <code>filter</code>, <code>select</code>, <code>mutate</code>, <code>group_by</code>, <code>summarise</code>, and the pipe.</p>
+  <div class="lesson-time">~30 min</div>
+</div>
 
-4. **Data Visualization**
-   - Creating basic plots.
-   - Customizing plots.
-   - Advanced visualization with ggplot2.
+<div class="lesson-card">
+  <div class="lesson-number">Lesson 4</div>
+  <h3><a href="data_visualization_r.html">Data Visualization</a></h3>
+  <p>The grammar of graphics with <code>ggplot2</code>: geoms, aesthetics, facets, themes, and saving plots.</p>
+  <div class="lesson-time">~30 min</div>
+</div>
 
-5. **Statistics with R**
-   - Descriptive statistics.
-   - Hypothesis testing.
-   - Regression analysis.
+<div class="lesson-card">
+  <div class="lesson-number">Lesson 5</div>
+  <h3><a href="statistics_with_r.html">Statistics with R</a></h3>
+  <p>Descriptive stats, t-tests, correlation, and linear regression — with diagnostics and predictions.</p>
+  <div class="lesson-time">~30 min</div>
+</div>
 
-## Contact Information
+<div class="lesson-card">
+  <div class="lesson-number">Lesson 6</div>
+  <h3><a href="rmarkdown_r.html">Reproducible Reports</a></h3>
+  <p>R Markdown: write code and prose together, knit to HTML or PDF, and share something a colleague can rerun.</p>
+  <div class="lesson-time">~20 min</div>
+</div>
 
-If you have any questions or need further assistance during the course, please don't hesitate to contact me:
+<div class="lesson-card">
+  <div class="lesson-number">Lesson 7</div>
+  <h3><a href="capstone_r.html">Capstone Project</a></h3>
+  <p>Put it all together: explore a real dataset, model it, and write up a short report — start to finish.</p>
+  <div class="lesson-time">~45 min</div>
+</div>
 
-- **Email:** cavandonohoe@gmail.com
+</div>
 
-Feel free to reach out for clarification, additional resources, or any other inquiries.
+## What you'll need
 
-Let's embark on this exciting journey of learning R together!
+- A computer running macOS, Windows, or Linux.
+- [R](https://cran.r-project.org/mirrors.html) installed (free).
+- [RStudio Desktop](https://posit.co/download/rstudio-desktop/) installed (also free) — this is the IDE we'll use.
+- About 2–3 hours total if you do the lessons end-to-end. You can also dip in and out.
 
+Lesson 1 walks you through the install if you haven't done it.
 
+## How to use this course
 
-Free Lessons:
+Each lesson page has runnable code blocks. The recommended workflow is:
 
-- [R Time Is Limited, Let's Make the Most of It](https://cavandonohoe.github.io/learn_r.html)
-- [Introduction to R](https://cavandonohoe.github.io/intro_to_r.html)
-- [Basic Operations in R](https://cavandonohoe.github.io/basic_operations_r.html)
-- [Data Manipulation](https://cavandonohoe.github.io/data_manipulation_r.html)
-- [Data Visualization](https://cavandonohoe.github.io/data_visualization_r.html)
-- [Statistics in R](https://cavandonohoe.github.io/statistics_with_r.html)
+1. Read a section.
+2. Open RStudio and **type the example yourself** (don't copy-paste — muscle memory matters).
+3. Try the exercises at the end of each section. Solutions are hidden behind a "Show solution" toggle so you can take a real swing first.
+
+<div class="callout callout-tip">
+<div class="callout-title">💡 Tip: pick a project early</div>
+You'll learn 5x faster if you have a real question you want to answer. Even something silly — "are NBA teams shooting more 3s than they used to?" — gives every concept a place to land. Pick one before you finish Lesson 2.
+</div>
+
+## Questions or feedback?
+
+If something is unclear, broken, or could be better, email me at **cavandonohoe@gmail.com** or open an issue on [GitHub](https://github.com/cavandonohoe/cavandonohoe.github.io). I genuinely want to make this better.
+
+<div class="lesson-nav">
+  <span class="nav-placeholder"></span>
+  <a class="nav-next" href="intro_to_r.html">
+    <span class="lesson-nav-label">Start here →</span>
+    <span class="lesson-nav-title">Lesson 1: Introduction to R</span>
+  </a>
+</div>

--- a/rmarkdown_r.Rmd
+++ b/rmarkdown_r.Rmd
@@ -1,0 +1,326 @@
+---
+title: "Lesson 6: Reproducible Reports with R Markdown"
+author: "Cavan Donohoe"
+description: "Write code and prose together, knit to HTML or PDF, and share something a colleague can rerun."
+output:
+  html_document:
+    toc: true
+    toc_float: true
+    includes:
+      in_header: header/header.html
+      after_body: include_footer.html
+lang: "en"
+---
+
+<link rel="stylesheet" href="/css/learn-r.css">
+
+<div class="course-progress">
+Lesson 6 of 7 · <a href="learn_r.html">Course overview</a>
+</div>
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(comment = "#>", message = FALSE, warning = FALSE)
+```
+
+# Reproducible Reports with R Markdown
+
+R Markdown is how R programmers write reports. You combine narrative prose, R code, and the *output* of that code (tables, plots, model summaries) into a single document. When you "knit" it, R runs all the code from scratch and produces an HTML, PDF, or Word file.
+
+Every lesson in this course was written in R Markdown. So is the page you're reading.
+
+The big win: **the report is the source of truth**. There's no copy-pasting numbers from R into Word, no screenshots of plots that you forgot to update. You change the data or the code, you re-knit, and everything updates.
+
+## The anatomy of an Rmd file
+
+An R Markdown file (`.Rmd`) has three kinds of content:
+
+1. A **YAML header** at the top, between `---` lines, that controls metadata (title, author, output format).
+2. **Markdown prose** — same as on GitHub, headings with `#`, lists with `-`, links with `[text](url)`.
+3. **Code chunks** — R code in fenced blocks, marked with `` ```{r} ``.
+
+A minimal example:
+
+````
+---
+title: "My First Report"
+author: "Your Name"
+output: html_document
+---
+
+## Setup
+
+```{r}`r ''`
+library(dplyr)
+```
+
+The mtcars dataset has `r '\x60r nrow(mtcars)\x60'` rows.
+
+```{r}`r ''`
+mtcars |> count(cyl)
+```
+````
+
+When you knit that, R runs the code chunks, captures their output, splices in the inline values (the <code>&#96;r nrow(mtcars)&#96;</code> syntax inside the prose), and renders the whole thing into HTML.
+
+## Creating an Rmd in RStudio
+
+In RStudio, **File → New File → R Markdown…** opens a dialog. Pick a title, an output format (HTML is the default), and click OK. RStudio creates a template you can knit immediately by clicking the **Knit** button in the toolbar (or pressing <kbd>Cmd</kbd>/<kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>K</kbd>).
+
+The first time you knit, it will install whatever packages are missing. Be patient.
+
+## Code chunks
+
+A code chunk looks like this in your `.Rmd` source:
+
+````
+```{r}`r ''`
+library(dplyr)
+mtcars |> count(cyl)
+```
+````
+
+The `{r}` says "this is R" — there are also chunks for Python, SQL, and a few other languages, but you'll mostly use R.
+
+Inside the curly braces you can pass **chunk options** that control how the chunk behaves:
+
+````
+```{r my-chunk-name, echo=FALSE, fig.width=8}`r ''`
+plot(mtcars$wt, mtcars$mpg)
+```
+````
+
+The most useful chunk options:
+
+| Option | What it does |
+|--------|--------------|
+| `echo = FALSE` | Hide the code, show the output (good for figures in a report) |
+| `eval = FALSE` | Show the code but don't run it (good for "here's how you'd do it" examples) |
+| `include = FALSE` | Run the code, but show nothing (good for setup chunks) |
+| `message = FALSE` | Suppress package startup messages |
+| `warning = FALSE` | Suppress warnings |
+| `fig.width`, `fig.height` | Set the size of any plots produced |
+| `cache = TRUE` | Cache the chunk's results to disk; only re-run if the code changes |
+
+You can set defaults for the whole document in a setup chunk near the top:
+
+````
+```{r setup, include=FALSE}`r ''`
+knitr::opts_chunk$set(
+  message = FALSE,
+  warning = FALSE,
+  fig.width = 7,
+  fig.height = 4
+)
+```
+````
+
+## Inline R
+
+The <code>&#96;r nrow(mtcars)&#96;</code> syntax inside the prose runs an R expression and splices the result into the text. It's how you keep numbers in your prose in sync with the data:
+
+```
+The dataset has `r '\x60r nrow(mtcars)\x60'` rows and
+`r '\x60r ncol(mtcars)\x60'` columns. The mean MPG is
+`r '\x60r round(mean(mtcars$mpg), 1)\x60'`.
+```
+
+When this knits, it produces:
+
+> The dataset has `r nrow(mtcars)` rows and `r ncol(mtcars)` columns. The mean MPG is `r round(mean(mtcars$mpg), 1)`.
+
+If the data changes, the numbers change. No manual edits.
+
+## Output formats
+
+The `output:` line in the YAML header picks the format. Common ones:
+
+```yaml
+output: html_document
+```
+
+```yaml
+output: pdf_document    # requires LaTeX (TinyTeX is easiest: tinytex::install_tinytex())
+```
+
+```yaml
+output: word_document
+```
+
+You can also customize the HTML output:
+
+```yaml
+output:
+  html_document:
+    toc: true
+    toc_float: true
+    code_folding: show
+    theme: cosmo
+    df_print: paged
+```
+
+- `toc: true` — generate a table of contents from your headings.
+- `toc_float: true` — make it sticky on the side as you scroll.
+- `code_folding: show` — readers can hide code chunks with one click.
+- `theme: cosmo` — Bootstrap theme. Try `"flatly"`, `"journal"`, `"cosmo"`, etc.
+- `df_print: paged` — pretty pagination for data frames.
+
+R Markdown can also produce slides (`output: ioslides_presentation` or `revealjs::revealjs_presentation`), websites, books, and dashboards. The package ecosystem here is huge.
+
+## A tiny worked example
+
+Here's a complete, working `.Rmd` file end to end. Save this as `cars_report.Rmd` and knit it:
+
+````
+---
+title: "Cars Report"
+author: "You"
+date: "`r '\x60r Sys.Date()\x60'`"
+output:
+  html_document:
+    toc: true
+    toc_float: true
+---
+
+```{r setup, include=FALSE}`r ''`
+knitr::opts_chunk$set(message = FALSE, warning = FALSE, fig.width = 6, fig.height = 4)
+library(dplyr)
+library(ggplot2)
+```
+
+## Overview
+
+This report uses the built-in `mtcars` dataset, which has
+`r '\x60r nrow(mtcars)\x60'` rows.
+
+## Distribution of MPG
+
+```{r}`r ''`
+ggplot(mtcars, aes(x = mpg)) +
+  geom_histogram(bins = 10, fill = "steelblue", color = "white") +
+  theme_minimal()
+```
+
+## Average MPG by cylinder count
+
+```{r}`r ''`
+mtcars |>
+  group_by(cyl) |>
+  summarise(mean_mpg = mean(mpg), n = n(), .groups = "drop")
+```
+
+## Conclusion
+
+Heavier, more-cylindered cars get worse mileage. Shocking.
+````
+
+Knit it once. Then change something — say, swap `mean` for `median`. Knit again. The whole report updates without you touching the prose.
+
+## Tips for real-world reports
+
+- **Keep one Rmd per analysis.** Don't try to put your whole life in one document.
+- **Put setup at the top.** All `library()` calls and `opts_chunk$set()` go in a single chunk near the top, often named `setup`.
+- **Name your chunks.** `{r my-thing}` instead of `{r}`. Makes errors much easier to find ("error in chunk *my-thing*").
+- **Cache slow chunks.** If something takes 30 seconds to run, set `cache = TRUE` so you don't re-run it on every knit.
+- **Don't fight the layout.** If you find yourself wanting fine control over fonts and margins, you might want a different tool (`quarto`, LaTeX, Word). R Markdown is amazing for "data-driven document," less so for "perfect typography."
+- **Quarto is the next-generation R Markdown.** Same idea, supports more languages, slightly better defaults. If you're starting fresh in 2025+, [Quarto](https://quarto.org/) is worth knowing about. The mental model is identical.
+
+<div class="callout callout-note">
+<div class="callout-title">📝 Quarto vs. R Markdown</div>
+Quarto (`.qmd` files) is essentially R Markdown's successor, built by the same team. It supports R, Python, Julia, and Observable in the same document, and has nicer defaults for things like cross-references. Everything you learn here transfers directly. For a personal site or one-off analysis, R Markdown is still totally fine.
+</div>
+
+<div class="exercise">
+<div class="exercise-title">✏️ Exercise 6.1 — Your first knitted document</div>
+
+Create a new R Markdown file in RStudio (File → New File → R Markdown). Replace the template content with:
+
+- A title and author in the YAML header.
+- A heading "About the data."
+- A short paragraph that uses inline R to report the number of rows in `mtcars`.
+- A code chunk that prints `summary(mtcars)`.
+- A code chunk that plots `mtcars$wt` vs. `mtcars$mpg`.
+
+Knit it to HTML. You should get a report with a working table of contents.
+
+<details>
+<summary>Show solution</summary>
+
+````
+---
+title: "Cars Quick Look"
+author: "Your Name"
+output:
+  html_document:
+    toc: true
+    toc_float: true
+---
+
+```{r setup, include=FALSE}`r ''`
+knitr::opts_chunk$set(message = FALSE, warning = FALSE)
+```
+
+## About the data
+
+The `mtcars` dataset has `r '\x60r nrow(mtcars)\x60'` rows and
+`r '\x60r ncol(mtcars)\x60'` columns.
+
+## Summary
+
+```{r}`r ''`
+summary(mtcars)
+```
+
+## Weight vs. MPG
+
+```{r}`r ''`
+plot(mtcars$wt, mtcars$mpg,
+  xlab = "Weight (1000 lbs)", ylab = "MPG",
+  main = "Heavier cars get worse mileage")
+```
+````
+
+</details>
+</div>
+
+<div class="exercise">
+<div class="exercise-title">✏️ Exercise 6.2 — Hide the code</div>
+
+Take the report from Exercise 6.1 and modify it so that the **code is hidden** in the knitted HTML — only the output (the summary table and the plot) shows. Add a single line so a reader can still toggle code on if they want.
+
+<details>
+<summary>Show solution</summary>
+
+Two changes:
+
+1. Add `echo=FALSE` to the global chunk options in the setup chunk.
+2. Add `code_folding: show` (or `hide`) to the YAML to put a toggle in the output.
+
+```yaml
+output:
+  html_document:
+    toc: true
+    toc_float: true
+    code_folding: hide
+```
+
+```r
+knitr::opts_chunk$set(echo = FALSE, message = FALSE, warning = FALSE)
+```
+
+</details>
+</div>
+
+## What's next
+
+You now know how to share an analysis as a real document. The last lesson is the capstone: a full, end-to-end project that puts every previous lesson together — load data, manipulate it, plot it, model it, and write it up.
+
+<div class="lesson-nav">
+  <a class="nav-prev" href="statistics_with_r.html">
+    <span class="lesson-nav-label">← Previous</span>
+    <span class="lesson-nav-title">Lesson 5: Statistics with R</span>
+  </a>
+  <a class="nav-next" href="capstone_r.html">
+    <span class="lesson-nav-label">Next →</span>
+    <span class="lesson-nav-title">Lesson 7: Capstone Project</span>
+  </a>
+</div>

--- a/statistics_with_r.Rmd
+++ b/statistics_with_r.Rmd
@@ -1,6 +1,7 @@
 ---
-title: "Statistics with R"
+title: "Lesson 5: Statistics with R"
 author: "Cavan Donohoe"
+description: "Descriptive statistics, t-tests, correlation, and linear regression — with diagnostics and predictions."
 output:
   html_document:
     toc: true
@@ -11,70 +12,378 @@ output:
 lang: "en"
 ---
 
+<link rel="stylesheet" href="/css/learn-r.css">
+
+<div class="course-progress">
+Lesson 5 of 7 · <a href="learn_r.html">Course overview</a>
+</div>
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(
+  comment = "#>",
+  message = FALSE,
+  warning = FALSE,
+  fig.width = 6.5,
+  fig.height = 4.2,
+  dpi = 100
+)
+options(scipen = 999, digits = 4)
+```
+
 # Statistics with R
 
-In this section, we will explore statistical analysis in R, covering descriptive statistics, hypothesis testing, and regression analysis.
+R was built by statisticians, so the basic statistics tools are right there in the base language. This lesson covers the four things you'll do most often:
 
-## Descriptive Statistics
+1. Descriptive statistics — summarising one variable.
+2. Comparing two groups — the t-test.
+3. Measuring association — correlation.
+4. Modeling — linear regression, with diagnostics and predictions.
 
-Descriptive statistics help you summarize and understand your data. Common descriptive statistics include measures of central tendency (mean, median, mode), measures of spread (variance, standard deviation, range), and graphical representations (histograms, box plots).
+We'll keep using `mtcars` so you can compare the numbers to the plots from Lesson 4.
 
-```{r}
-# Descriptive statistics example
-data <- c(12, 15, 18, 22, 25, 28, 31)
-
-# Mean and median
-mean_data <- mean(data)
-mean_data
-
-median_data <- median(data)
-median_data
-
-# Variance and standard deviation
-variance_data <- var(data)
-variance_data
-
-sd_data <- sd(data)
-sd_data
-
-# Histogram
-hist(data, main = "Histogram of Data", xlab = "Value", ylab = "Frequency")
-```
-
-## Hypothesis Testing
-Hypothesis testing is a crucial statistical technique to make inferences about populations based on sample data. In R, you can perform hypothesis tests for means, proportions, variances, and more. Here's an example of a t-test for comparing two sample means:
+## Setup
 
 ```{r}
-# Hypothesis testing example (t-test)
-group1 <- c(10, 12, 14, 16, 18)
-group2 <- c(14, 15, 16, 17, 18)
+library(dplyr)
+library(ggplot2)
 
-t_test_result <- t.test(group1, group2)
-t_test_result
+cars <- mtcars |>
+  tibble::rownames_to_column("model") |>
+  tibble::as_tibble()
 ```
 
-## Regression Analysis
-Regression analysis helps you model and analyze relationships between variables. You can perform linear regression, logistic regression, and other types of regression analysis in R. Here's a simple linear regression example:
+## Descriptive statistics
+
+The most common single-variable summaries:
 
 ```{r}
-# Linear regression example
-x <- c(1, 2, 3, 4, 5)
-y <- c(2, 4, 5, 4, 6)
-
-linear_model <- lm(y ~ x)
-summary(linear_model)
+mean(cars$mpg)
+median(cars$mpg)
+sd(cars$mpg)              # standard deviation
+var(cars$mpg)             # variance
+min(cars$mpg)
+max(cars$mpg)
+range(cars$mpg)
+quantile(cars$mpg, probs = c(0.25, 0.5, 0.75))
+IQR(cars$mpg)
 ```
 
-In this section, we've covered the essentials of statistical analysis in R, including descriptive statistics, hypothesis testing, and regression analysis. These statistical tools are invaluable for drawing insights and making data-driven decisions.
+`summary()` prints a quick five-number summary plus the mean — handy for a first look at any variable or data frame:
 
-Feel free to explore more advanced statistical techniques and datasets to deepen your understanding of statistics with R.
+```{r}
+summary(cars$mpg)
+summary(cars)
+```
 
+For grouped summaries, use `dplyr` from Lesson 3:
 
-Free Lessons:
+```{r}
+cars |>
+  group_by(cyl) |>
+  summarise(
+    n = n(),
+    mean_mpg = mean(mpg),
+    sd_mpg = sd(mpg),
+    median_mpg = median(mpg),
+    .groups = "drop"
+  )
+```
 
-- [R Time Is Limited, Let's Make the Most of It](https://cavandonohoe.github.io/learn_r.html)
-- [Introduction to R](https://cavandonohoe.github.io/intro_to_r.html)
-- [Basic Operations in R](https://cavandonohoe.github.io/basic_operations_r.html)
-- [Data Manipulation](https://cavandonohoe.github.io/data_manipulation_r.html)
-- [Data Visualization](https://cavandonohoe.github.io/data_visualization_r.html)
-- [Statistics in R](https://cavandonohoe.github.io/statistics_with_r.html)
+<div class="callout callout-tip">
+<div class="callout-title">💡 Always look before you test</div>
+Before running a t-test or fitting a model, make a plot. A boxplot or histogram will tell you in three seconds whether the assumptions you're about to make (normality, equal variance, no crazy outliers) are even close to true.
+</div>
+
+## Comparing two groups: the t-test
+
+A t-test answers: "Are the means of two groups different by more than I'd expect from random sampling?"
+
+Question: do manual cars get better gas mileage than automatic cars on average?
+
+```{r fig.height=3.5}
+ggplot(cars, aes(x = factor(am, labels = c("automatic", "manual")), y = mpg)) +
+  geom_boxplot(fill = "lightsteelblue") +
+  labs(x = "Transmission", y = "MPG", title = "MPG by transmission type") +
+  theme_minimal()
+```
+
+The boxplot suggests yes. Let's quantify it:
+
+```{r}
+t_result <- t.test(mpg ~ am, data = cars)
+t_result
+```
+
+How to read the output:
+
+- **`t = -3.77`** — the test statistic. Bigger absolute value = stronger evidence the means differ.
+- **`df`** — degrees of freedom (Welch's t-test uses fractional df, that's fine).
+- **`p-value = 0.001374`** — probability of seeing a difference this large (or larger) if the true means were actually equal. By the conventional cutoff of 0.05, this is "significant."
+- **`95 percent confidence interval: -11.28, -3.21`** — we're 95% confident the true difference (automatic minus manual) is between about -11 and -3 MPG.
+- **`mean in group 0 = 17.15, mean in group 1 = 24.39`** — the actual group means.
+
+So manual cars in this dataset get around **7 MPG more** than automatic cars on average, and the difference is statistically significant.
+
+You can pull individual pieces out programmatically:
+
+```{r}
+t_result$p.value
+t_result$conf.int
+t_result$estimate
+```
+
+<div class="callout callout-warning">
+<div class="callout-title">⚠️ "Significant" doesn't mean "important"</div>
+A tiny effect with a huge sample will be "statistically significant." A huge effect with a small sample may not be. Always look at the confidence interval and the effect size, not just the p-value.
+
+Also: this comparison ignores that manuals tend to be in different cars than automatics (lighter, fewer cylinders, etc.). The honest answer to "does transmission cause better MPG" requires a model that controls for those things — that's what regression is for.
+</div>
+
+## Measuring association: correlation
+
+Correlation measures how strongly two numeric variables move together, on a scale of -1 to 1.
+
+```{r}
+cor(cars$wt, cars$mpg)
+```
+
+A correlation of about -0.87: strong negative association. As weight goes up, MPG goes down.
+
+`cor.test()` adds a hypothesis test (is the correlation different from zero?) and a confidence interval:
+
+```{r}
+cor.test(cars$wt, cars$mpg)
+```
+
+For a whole correlation matrix:
+
+```{r}
+cars |>
+  select(mpg, hp, wt, drat, qsec) |>
+  cor() |>
+  round(2)
+```
+
+## Linear regression
+
+Regression is the workhorse of applied statistics. The basic question: "How does the response variable change as the predictors change?"
+
+### A simple regression
+
+Predict MPG from weight:
+
+```{r}
+fit1 <- lm(mpg ~ wt, data = cars)
+fit1
+```
+
+The formula `mpg ~ wt` reads as "model `mpg` as a function of `wt`." `lm()` returns a fitted model object — print it for a quick look, `summary()` for the full output:
+
+```{r}
+summary(fit1)
+```
+
+What's important here:
+
+- **Coefficients:** `wt = -5.34` means each additional 1000 lbs of weight is associated with a **5.34-MPG decrease**, on average.
+- **`Pr(>|t|)` for `wt`:** the p-value for "is this coefficient different from 0?" Tiny — yes.
+- **R-squared = 0.75:** 75% of the variation in MPG is explained by weight alone.
+- **Residual standard error:** typical prediction error in MPG units.
+
+### A multiple regression
+
+Add more predictors with `+`:
+
+```{r}
+fit2 <- lm(mpg ~ wt + hp + factor(cyl), data = cars)
+summary(fit2)
+```
+
+Now we're estimating the effect of weight **after controlling for** horsepower and cylinder count.
+
+`factor(cyl)` tells R to treat `cyl` as a categorical variable rather than a number. The output gives you the difference between each level and a reference level (here, 4-cylinder).
+
+### Comparing models
+
+`anova()` tests whether the bigger model is significantly better than the smaller one:
+
+```{r}
+anova(fit1, fit2)
+```
+
+A small p-value means the extra predictors are pulling weight (so to speak).
+
+`AIC()` and `BIC()` are alternative model-comparison metrics — lower is better:
+
+```{r}
+AIC(fit1, fit2)
+```
+
+### Diagnostics
+
+Before trusting a regression, look at the diagnostic plots. R's built-in `plot()` on a model gives you four:
+
+```{r fig.width=7, fig.height=5}
+par(mfrow = c(2, 2))
+plot(fit1)
+par(mfrow = c(1, 1))
+```
+
+What you're looking for:
+
+- **Residuals vs. Fitted** — should look like a flat blob with no pattern. A curve suggests you're missing nonlinearity.
+- **Q-Q Residuals** — should hug the diagonal line. Big departures = non-normal residuals.
+- **Scale-Location** — should be roughly flat. A trend means the variance changes with the fitted value (heteroscedasticity).
+- **Residuals vs. Leverage** — points with high Cook's distance (top-right or bottom-right corners, past the dashed lines) are unusually influential. Investigate those rows.
+
+### Predictions
+
+Once you have a model, you can predict new values:
+
+```{r}
+new_cars <- tibble::tibble(wt = c(2.0, 3.5, 5.0))
+predict(fit1, newdata = new_cars)
+```
+
+Add a confidence interval for the *mean* response:
+
+```{r}
+predict(fit1, newdata = new_cars, interval = "confidence")
+```
+
+Or a prediction interval for a *single new observation* (wider, because individual cars vary):
+
+```{r}
+predict(fit1, newdata = new_cars, interval = "prediction")
+```
+
+### Visualizing the fit
+
+A simple regression line is one geom away in ggplot:
+
+```{r fig.height=3.8}
+ggplot(cars, aes(x = wt, y = mpg)) +
+  geom_point(size = 2.5, alpha = 0.8) +
+  geom_smooth(method = "lm", se = TRUE, color = "steelblue") +
+  labs(
+    title = "MPG vs. Weight, with linear fit and 95% CI",
+    x = "Weight (1000 lbs)", y = "MPG"
+  ) +
+  theme_minimal()
+```
+
+`geom_smooth(method = "lm")` is fitting the same model as `lm(mpg ~ wt)` under the hood and shading the confidence band.
+
+## A few other tests worth knowing
+
+- `wilcox.test()` — non-parametric alternative to the t-test (for non-normal data).
+- `chisq.test()` — chi-square test for independence between two categorical variables.
+- `prop.test()` — comparing proportions across groups.
+- `aov()` — ANOVA, for comparing means across more than two groups.
+- `glm(..., family = binomial)` — logistic regression, for binary outcomes.
+
+The pattern is the same across all of them: a formula, a data argument, a summary or print of the result.
+
+## Putting it together
+
+A complete mini-analysis: is MPG associated with weight, controlling for horsepower? Report the model, check assumptions, and predict MPG for a hypothetical new car.
+
+```{r}
+fit <- lm(mpg ~ wt + hp, data = cars)
+summary(fit)
+```
+
+Coefficient interpretations: holding horsepower constant, each additional 1000 lbs of weight is associated with a `r round(coef(fit)["wt"], 2)`-MPG decrease. Holding weight constant, each additional horsepower is associated with a `r round(coef(fit)["hp"], 4)`-MPG decrease.
+
+Quick diagnostic look:
+
+```{r fig.width=7, fig.height=3.5}
+par(mfrow = c(1, 2))
+plot(fit, which = c(1, 2))
+par(mfrow = c(1, 1))
+```
+
+Predict MPG for a 3500-lb car with 130 hp:
+
+```{r}
+predict(fit, newdata = tibble::tibble(wt = 3.5, hp = 130), interval = "prediction")
+```
+
+That's a complete (if minimal) regression analysis: fit, interpret, diagnose, predict.
+
+<div class="exercise">
+<div class="exercise-title">✏️ Exercise 5.1 — Descriptive stats</div>
+
+Compute the mean, median, standard deviation, and IQR of `cars$hp`. Are the mean and median similar? What does that tell you about the distribution?
+
+<details>
+<summary>Show solution</summary>
+
+```{r}
+mean(cars$hp)
+median(cars$hp)
+sd(cars$hp)
+IQR(cars$hp)
+```
+
+The mean is noticeably higher than the median, which means the distribution is right-skewed — there are a few high-horsepower outliers pulling the mean up. A boxplot or histogram would confirm.
+
+```{r fig.height=3}
+ggplot(cars, aes(x = hp)) +
+  geom_histogram(bins = 12, fill = "steelblue", color = "white") +
+  theme_minimal()
+```
+
+</details>
+</div>
+
+<div class="exercise">
+<div class="exercise-title">✏️ Exercise 5.2 — A t-test</div>
+
+Test whether 4-cylinder cars have a different mean MPG than 8-cylinder cars. Report the p-value, the 95% CI, and a one-sentence interpretation.
+
+<details>
+<summary>Show solution</summary>
+
+```{r}
+sub <- cars |> filter(cyl %in% c(4, 8))
+t.test(mpg ~ cyl, data = sub)
+```
+
+The mean MPG of 4-cylinder cars is roughly 11 MPG higher than 8-cylinder cars (95% CI ~9 to 13), and the p-value is tiny — the difference is far more than chance.
+
+</details>
+</div>
+
+<div class="exercise">
+<div class="exercise-title">✏️ Exercise 5.3 — A regression</div>
+
+Fit a model that predicts MPG from weight, horsepower, and cylinder count (treat `cyl` as a factor). Which coefficients are statistically significant? What's the R-squared?
+
+<details>
+<summary>Show solution</summary>
+
+```{r}
+fit <- lm(mpg ~ wt + hp + factor(cyl), data = cars)
+summary(fit)
+```
+
+`wt` has a clearly significant negative coefficient. `hp` and the cylinder-count contrasts get smaller and may no longer be significant once weight is in the model — they're correlated with weight (heavier cars tend to have more cylinders and more horsepower), so a lot of the "effect" of cylinders is really just weight. Adjusted R-squared should be around 0.83.
+
+</details>
+</div>
+
+## What's next
+
+You can now load data, manipulate it, plot it, and run real statistical analyses on it. The last two lessons stop adding new tools and start showing how to **package up an analysis** so someone else (or future-you) can run it again. Lesson 6 is R Markdown — the document format this whole course is written in.
+
+<div class="lesson-nav">
+  <a class="nav-prev" href="data_visualization_r.html">
+    <span class="lesson-nav-label">← Previous</span>
+    <span class="lesson-nav-title">Lesson 4: Data Visualization</span>
+  </a>
+  <a class="nav-next" href="rmarkdown_r.html">
+    <span class="lesson-nav-label">Next →</span>
+    <span class="lesson-nav-title">Lesson 6: Reproducible Reports</span>
+  </a>
+</div>


### PR DESCRIPTION
## Summary

The old Learn R section was buried in **Projects → Archive** and each lesson was a few bullet points and a couple of trivial code examples. This rebuilds it into a proper seven-lesson hands-on course.

### Structure changes

- **Promote Learn R to a top-level navbar menu** with its own graduation-cap icon. Lessons are numbered 1–7 in order so it's obvious where to start.
- **New landing page** (`learn_r.Rmd`) with lesson cards, "what you'll build," prerequisites, time estimates per lesson, and a clearer pitch for *why* you'd want to learn R.

### Content expansion

All five existing lessons rewritten with much more depth, plus two new lessons:

| # | Lesson | What's new |
|---|---|---|
| 1 | Introduction to R | Adds installing packages, `?help`, first runnable script |
| 2 | Basic Operations | Adds comparison/logical ops, NA handling, lists, control flow, writing functions |
| 3 | Data Manipulation | Rewritten around the tidyverse — `filter`/`select`/`mutate`/`group_by`/`summarise`, the pipe, joins, `pivot_*` |
| 4 | Data Visualization | Real ggplot2 walkthrough — geoms, aesthetics vs. fixed values, facets, scales, themes, `ggsave` |
| 5 | Statistics with R | Adds correlation, model comparison (`anova`, `AIC`), diagnostic plots, predictions with intervals |
| 6 | **NEW**: Reproducible Reports | R Markdown — chunks, options, inline R, output formats, code folding |
| 7 | **NEW**: Capstone | End-to-end mini-analysis on the `airquality` dataset (load → explore → plot → t-test → regression → diagnostics → predict → write up) |

Every lesson ends with 2–3 exercises whose solutions are hidden behind `<details>` toggles, so you can take a real swing before peeking.

### Styling

- New `css/learn-r.css` for lesson cards, callout boxes, exercise blocks, and prev/next navigation between lessons.
- Uses the existing site CSS variables (`--card-bg`, `--text-color`, etc.), so dark mode just works.

## Test plan

- [x] All 8 documents (landing + 7 lessons) render via `rmarkdown::render_site()` with no errors
- [x] Verified inline R chunks (e.g. `mean(...)`) evaluate where intended and stay literal where intended (the R Markdown lesson explains the syntax, so it has to show literal `` `r ...` `` markers in the prose without evaluating them)
- [x] Verified the new navbar menu appears on `index.html` with all 7 lessons
- [x] Verified `details`/`summary` exercise toggles render correctly
- [x] Verified prev/next nav appears at the bottom of each lesson and links to the right adjacent lesson
- [x] No new typos (ran `typos` locally)
- [ ] Manual visual check after deploy preview lands