### PR TITLE
Style figure captions and add spacing below

### DIFF
--- a/header/header.html
+++ b/header/header.html
@@ -116,6 +116,19 @@ body {
 .project-card h3 { font-size: 1.05em; margin: 0 0 0.4em 0; color: var(--link-color) !important; }
 .project-card p { font-size: 0.88em; color: var(--muted-text); margin: 0; line-height: 1.4; }
 
+/* Figure captions (rendered from markdown image alt text) */
+.float {
+  margin-bottom: 2.5em;
+}
+.figcaption {
+  font-size: 0.88em;
+  font-style: italic;
+  color: var(--muted-text);
+  text-align: center;
+  margin-top: 0.5em;
+  line-height: 1.4;
+}
+
 /* Timestamp badges */
 .data-timestamp {
   display: inline-block;


### PR DESCRIPTION
## Summary
- Style `.figcaption` (rendered from markdown image alt text) as a proper caption: smaller, italic, centered, soft gray via `--muted-text` so it works in both light and dark mode.
- Add `margin-bottom: 2.5em` to the `.float` wrapper so the next paragraph has breathing room below the captioned image.

Applies site-wide; visible on the home page (China Walls) and About page (volleyball, mermaid).