### PR TITLE
Add weekly Supabase ping for movie-ranker project

### DIFF
--- a/.github/workflows/ping-movie-ranker-supabase.yml
+++ b/.github/workflows/ping-movie-ranker-supabase.yml
@@ -1,0 +1,57 @@
+name: Ping movie-ranker Supabase
+
+# Free-tier Supabase projects auto-pause after ~7 days of inactivity. This
+# workflow makes a cheap read query against the project once a week so it
+# never sits idle long enough to trigger the pause.
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "17 14 * * 1"  # Mondays 14:17 UTC
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ping-movie-ranker-supabase
+  cancel-in-progress: false
+
+jobs:
+  ping:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      SUPABASE_URL: ${{ secrets.MOVIE_RANKER_SUPABASE_URL }}
+      SUPABASE_ANON_KEY: ${{ secrets.MOVIE_RANKER_SUPABASE_ANON_KEY }}
+    steps:
+      - name: Verify secrets present
+        run: |
+          set -euo pipefail
+          if [ -z "${SUPABASE_URL:-}" ] || [ -z "${SUPABASE_ANON_KEY:-}" ]; then
+            echo "::error::MOVIE_RANKER_SUPABASE_URL and MOVIE_RANKER_SUPABASE_ANON_KEY must be set as repo secrets."
+            exit 1
+          fi
+
+      - name: Read one row from public.titles
+        run: |
+          set -euo pipefail
+          # `Range: 0-0` returns at most one row; the response itself is
+          # ignored — what matters is that the DB processed a query.
+          status=$(curl -s -o /tmp/resp.json -w "%{http_code}" \
+            -H "apikey: ${SUPABASE_ANON_KEY}" \
+            -H "Authorization: Bearer ${SUPABASE_ANON_KEY}" \
+            -H "Range: 0-0" \
+            "${SUPABASE_URL}/rest/v1/titles?select=id")
+          echo "HTTP ${status}"
+          # PostgREST returns 200 for full ranges and 206 for partial — both
+          # are healthy. Anything else means the project is unreachable or
+          # the keys are wrong, and the workflow should fail loudly.
+          case "${status}" in
+            200|206) ;;
+            *)
+              echo "::error::Unexpected HTTP ${status} from Supabase REST API."
+              cat /tmp/resp.json || true
+              exit 1
+              ;;
+          esac
+          echo "Supabase project pinged successfully."


### PR DESCRIPTION
## Summary
- Add a scheduled GitHub Actions workflow that hits the `movie-ranker` Supabase project once a week.
- Free-tier Supabase auto-pauses projects after ~7 days of inactivity. A trivial weekly read against `public.titles` resets that timer so the project stays online.
- Workflow runs every Monday at 14:17 UTC and is also `workflow_dispatch`-able from the Actions tab.

## Setup
Two repo secrets are already configured:

- `MOVIE_RANKER_SUPABASE_URL` — `https://<ref>.supabase.co`
- `MOVIE_RANKER_SUPABASE_ANON_KEY` — publishable key (safe to ship; same one the browser uses)

## Behavior
- One `curl` to `/rest/v1/titles?select=id` with `Range: 0-0`. Cheap. No writes.
- Workflow fails (and you'd get a GitHub email) if the DB is unreachable or the keys are wrong, so a real outage doesn't slip by silently.

## Test plan
- [ ] Merge to `main` so the workflow is registered.
- [ ] Run `gh workflow run ping-movie-ranker-supabase.yml` and confirm the job exits green.
- [ ] Confirm the cron line shows up under the Actions tab's scheduled runs.