### PR TITLE
Bump movie-ranker personal CSV workflow timeout to 30m

### DIFF
--- a/.github/workflows/update_movie_ranker_personal.yml
+++ b/.github/workflows/update_movie_ranker_personal.yml
@@ -23,7 +23,7 @@ concurrency:
 jobs:
   update:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
     env:
       MOVIE_RANKER_SUPABASE_URL: ${{ secrets.MOVIE_RANKER_SUPABASE_URL }}
       MOVIE_RANKER_SUPABASE_SERVICE_KEY: ${{ secrets.MOVIE_RANKER_SUPABASE_SERVICE_KEY }}


### PR DESCRIPTION
## Summary

The first dispatched run of `update_movie_ranker_personal.yml` hit the **15-minute job timeout** while `r-lib/actions/setup-r@v2` was still apt-installing R itself — the script never ran. R-based jobs across the repo ran **3–9× slower than baseline today** (data: Build site 32m vs ~4m baseline; PR Rmd smoke 13m vs ~2m), so 15 minutes was too tight a budget when the mirror is degraded.

Bumping to 30 minutes leaves plenty of headroom for slow days while still catching real hangs — the actual R script work is ~3 seconds, the rest is install.

## Test plan

- [ ] After merge, manually dispatch the workflow on `main` and confirm it completes successfully.