### PR TITLE
Run movie-ranker personal CSV workflow in rocker/r-ver container

### DIFF
--- a/.github/workflows/update_movie_ranker_personal.yml
+++ b/.github/workflows/update_movie_ranker_personal.yml
@@ -31,6 +31,12 @@ jobs:
     timeout-minutes: 15
     container:
       image: rocker/r-ver:4.4
+    # Default shell inside containers is `sh`, but several steps use bash
+    # features (pipefail, [[ ]], $(...) inside heredocs). bash is preinstalled
+    # in rocker/r-ver.
+    defaults:
+      run:
+        shell: bash
     env:
       MOVIE_RANKER_SUPABASE_URL: ${{ secrets.MOVIE_RANKER_SUPABASE_URL }}
       MOVIE_RANKER_SUPABASE_SERVICE_KEY: ${{ secrets.MOVIE_RANKER_SUPABASE_SERVICE_KEY }}

--- a/.github/workflows/update_movie_ranker_personal.yml
+++ b/.github/workflows/update_movie_ranker_personal.yml
@@ -7,6 +7,11 @@ name: Update movie-ranker personal CSV
 #
 # The file changes whenever a comparison or manual override is recorded in
 # the app, so we run on a 6h cadence plus on-demand dispatch.
+#
+# Runs in the rocker/r-ver:4.4 container (R 4.4.3, ubuntu noble) so we skip
+# the ~7-minute apt install of R that setup-r@v2 does on a bare ubuntu-latest
+# runner. R packages are restored from actions/cache keyed on the install
+# command so cold starts are ~2 min and warm runs are <30 sec.
 
 on:
   workflow_dispatch:
@@ -23,11 +28,23 @@ concurrency:
 jobs:
   update:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 15
+    container:
+      image: rocker/r-ver:4.4
     env:
       MOVIE_RANKER_SUPABASE_URL: ${{ secrets.MOVIE_RANKER_SUPABASE_URL }}
       MOVIE_RANKER_SUPABASE_SERVICE_KEY: ${{ secrets.MOVIE_RANKER_SUPABASE_SERVICE_KEY }}
     steps:
+      # rocker/r-ver doesn't ship git, but actions/checkout needs it for a
+      # full clone. Install just git here; everything else (curl, R, build
+      # toolchain, RSPM repo) is already in the image.
+      - name: Install git
+        run: |
+          set -euo pipefail
+          apt-get update -qq
+          apt-get install -y --no-install-recommends git
+          git --version
+
       - uses: actions/checkout@v6
 
       - name: Verify secrets present
@@ -41,30 +58,32 @@ jobs:
             exit 1
           fi
 
-      - uses: r-lib/actions/setup-r@v2
+      # Cache the site library across runs. Bump CACHE_VERSION below to force
+      # a rebuild if the package set changes.
+      - name: Cache R library
+        id: rcache
+        uses: actions/cache@v4
         with:
-          use-public-rspm: true
+          path: /usr/local/lib/R/site-library
+          # v1 = initial set: dplyr, tibble, readr, here, httr2, jsonlite, purrr
+          key: rlib-rocker-r-ver-4.4-v1
+          restore-keys: |
+            rlib-rocker-r-ver-4.4-
 
-      - uses: r-lib/actions/setup-r-dependencies@v2
-        with:
-          packages: |
-            any::dplyr
-            any::tibble
-            any::readr
-            any::here
-            any::httr2
-            any::jsonlite
-            any::purrr
+      - name: Install R packages if cache miss
+        if: steps.rcache.outputs.cache-hit != 'true'
+        run: |
+          Rscript -e 'install.packages(c("dplyr","tibble","readr","here","httr2","jsonlite","purrr"), Ncpus = 2)'
 
       - name: Replay Elo and write personal CSV
         run: Rscript scripts/update_movie_ranker_personal.R
 
-      # Sanity check: only the personal CSV is allowed to change. If anything
-      # else moved we abort before commit so a stray script can't push
-      # unrelated mutations.
+      # Sanity check: only the personal CSV is allowed to change.
       - name: Verify only personal CSV changed
         run: |
           set -euo pipefail
+          # Container runs as root; mark workspace safe so git stops complaining.
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
           unexpected="$(git diff --name-only HEAD \
             | grep -Ev '^data/movie_ranker_personal\.csv$' || true)"
           if [ -n "$unexpected" ]; then
@@ -79,6 +98,7 @@ jobs:
         run: |
           set -euo pipefail
 
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
@@ -118,10 +138,21 @@ jobs:
           exit 1
 
       # Bot pushes via GITHUB_TOKEN don't trigger downstream workflows
-      # (GitHub anti-recursion guard), so the site won't redeploy after this
-      # commit unless we explicitly dispatch the build workflow.
+      # (GitHub anti-recursion guard), so the site won't redeploy after our
+      # commit unless we explicitly dispatch the build workflow. Use plain
+      # curl against the REST API so we don't need to install gh inside the
+      # container.
       - name: Trigger site redeploy
         if: steps.push.outputs.pushed == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh workflow run pages-branch-previews.yml --ref main
+        run: |
+          set -euo pipefail
+          curl -fsSL \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/workflows/pages-branch-previews.yml/dispatches" \
+            -d '{"ref":"main"}'
+          echo "Dispatched pages-branch-previews.yml"


### PR DESCRIPTION
## Summary
- Switch `update_movie_ranker_personal.yml` to run inside `rocker/r-ver:4.4` so we skip the ~7-minute `setup-r@v2` apt install of R that dominates every run.
- Cache `/usr/local/lib/R/site-library` directly via `actions/cache` keyed on the package list (no `setup-r-dependencies`).
- Lower `timeout-minutes` from 30 back to 15.

## Why now
Most recent successful run (#27787843638) took 8m43s. Of that, ~7 min was setup-r@v2 apt-installing R itself, ~20 sec was the cached package restore, ~3 sec was the actual R script. Multiple earlier runs timed out altogether because of slow Azure apt mirrors. The container fixes the bottleneck at the source.

## Expected timings
- **Cold cache**: ~2 min (image pull + binary install of dplyr/tibble/readr/here/httr2/jsonlite/purrr from RSPM).
- **Warm cache**: well under 30 sec; the only real work is `git`, the Rscript, and the dispatch.

## Implementation notes
- `rocker/r-ver:4.4` doesn't ship `git`, so a small `apt-get install -y --no-install-recommends git` runs first.
- Container runs as root, so each `git` step does `git config --global --add safe.directory "$GITHUB_WORKSPACE"`.
- `gh` isn't in the image either, so the redeploy dispatch was rewritten as a `curl` call to the workflow_dispatch REST endpoint.

## Test plan
- [ ] CI passes on the PR (only this workflow changed; the other workflows are unaffected).
- [ ] After merge, manually dispatch on `main` and confirm the run completes in < 3 min cold, < 1 min warm.
- [ ] Confirm `data/movie_ranker_personal.csv` updates and the `pages-branch-previews.yml` redeploy is triggered.