### PR TITLE
Add testthat scaffold and CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,49 @@
+name: R tests
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "scripts/**/*.R"
+      - "tests/**/*.R"
+      - ".github/workflows/test.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "scripts/**/*.R"
+      - "tests/**/*.R"
+      - ".github/workflows/test.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: test-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  testthat:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          packages: |
+            any::testthat
+
+      - name: Run testthat
+        run: |
+          Rscript -e '
+            results <- testthat::test_dir("tests/testthat", reporter = "summary")
+            df <- as.data.frame(results)
+            if (any(df$failed > 0) || any(df$error)) {
+              quit(status = 1)
+            }
+          '

--- a/scripts/generate_sitemap.R
+++ b/scripts/generate_sitemap.R
@@ -30,15 +30,7 @@ out_path <- file.path(repo_root, "sitemap.xml")
 
 today <- format(Sys.Date(), "%Y-%m-%d")
 
-extract_hrefs <- function(node) {
-  if (is.list(node)) {
-    direct <- if (!is.null(node$href)) node$href else character()
-    nested <- unlist(lapply(node, extract_hrefs), use.names = FALSE)
-    c(direct, nested)
-  } else {
-    character()
-  }
-}
+source(file.path(repo_root, "scripts", "site_helpers.R"))
 
 hrefs_yml <- character()
 if (file.exists(site_yml)) {

--- a/scripts/site_helpers.R
+++ b/scripts/site_helpers.R
@@ -1,0 +1,23 @@
+#!/usr/bin/env Rscript
+# site_helpers.R
+#
+# Pure helper functions used by other site-build scripts. These are
+# kept separate so they can be unit-tested in isolation
+# (see tests/testthat/test-site_helpers.R).
+
+#' Recursively extract all `href` values from a (possibly nested) list.
+#'
+#' Walks a list (typically the parsed contents of `_site.yml`) and returns
+#' every value found under an `href` key, at any depth, in document order.
+#'
+#' @param node A list, named list, or atomic value.
+#' @return A character vector of `href` values (zero-length if none found).
+extract_hrefs <- function(node) {
+  if (is.list(node)) {
+    direct <- if (!is.null(node$href)) node$href else character()
+    nested <- unlist(lapply(node, extract_hrefs), use.names = FALSE)
+    c(direct, nested)
+  } else {
+    character()
+  }
+}

--- a/tests/testthat/test-site_helpers.R
+++ b/tests/testthat/test-site_helpers.R
@@ -1,0 +1,68 @@
+test_that("extract_hrefs returns empty for non-list input", {
+  source("../../scripts/site_helpers.R")
+
+  expect_equal(extract_hrefs("not a list"), character())
+  expect_equal(extract_hrefs(42), character())
+  expect_equal(extract_hrefs(NULL), character())
+})
+
+test_that("extract_hrefs finds a top-level href", {
+  source("../../scripts/site_helpers.R")
+
+  result <- extract_hrefs(list(href = "index.html"))
+  expect_equal(result, "index.html")
+})
+
+test_that("extract_hrefs walks nested lists", {
+  source("../../scripts/site_helpers.R")
+
+  nav <- list(
+    navbar = list(
+      left = list(
+        list(text = "Home", href = "index.html"),
+        list(text = "About", href = "about.html"),
+        list(
+          text = "Projects",
+          menu = list(
+            list(text = "Foo", href = "foo.html"),
+            list(text = "Bar", href = "bar.html")
+          )
+        )
+      ),
+      right = list(
+        list(icon = "github", href = "https://github.com/example")
+      )
+    )
+  )
+  result <- extract_hrefs(nav)
+  expect_setequal(
+    result,
+    c(
+      "index.html",
+      "about.html",
+      "foo.html",
+      "bar.html",
+      "https://github.com/example"
+    )
+  )
+})
+
+test_that("extract_hrefs handles entries without href", {
+  source("../../scripts/site_helpers.R")
+
+  nav <- list(
+    list(text = "Section header (no link)"),
+    list(text = "Real link", href = "page.html")
+  )
+  expect_equal(extract_hrefs(nav), "page.html")
+})
+
+test_that("extract_hrefs preserves duplicates", {
+  source("../../scripts/site_helpers.R")
+
+  nav <- list(
+    list(href = "page.html"),
+    list(href = "page.html")
+  )
+  expect_equal(extract_hrefs(nav), c("page.html", "page.html"))
+})


### PR DESCRIPTION
Partial progress on #97. Scaffolds the test side of the issue; defers the rest with rationale.

## What

- New \`scripts/site_helpers.R\` containing \`extract_hrefs()\` extracted from \`scripts/generate_sitemap.R\` so it can be unit-tested in isolation. \`generate_sitemap.R\` now \`source()\`s it.
- New \`tests/testthat/test-site_helpers.R\` with 5 cases:
  - empty input
  - single top-level href
  - nested walk through a multi-level navbar
  - entries without \`href\`
  - duplicate hrefs preserved
- New \`.github/workflows/test.yml\` running \`testthat::test_dir(\"tests/testthat\")\` on push and PR.

## Why this scope

Re-reading #97 against the repo:

- **Lintr**: \`lint.yml\` already exists. It's currently non-enforcing because a fresh repo-wide lint surfaces ~200 lints across older Rmds; flipping enforcement on now would block every PR. That's its own cleanup project.
- **Rmd render check**: \`pr-smoke.yml\` already renders changed Rmds on every PR.
- **Tests**: there was no testing infrastructure at all. That's the gap this PR closes.

The intent is for this to be the start of a real test suite, not the end. Future PRs should extract more pure helpers into \`scripts/site_helpers.R\` (or split as appropriate) and add tests.

## Test plan

- [x] Tests pass locally: \`Rscript -e 'testthat::test_dir(\"tests/testthat\")'\` shows \`PASS 7\`
- [x] \`generate_sitemap.R\` still produces the same 33-URL sitemap (only the \`<lastmod>\` date changed, matching the daily refresh behavior)
- [ ] CI \`R tests\` workflow passes on this PR