### PR TITLE
Add CONTRIBUTING.md and slim duplicated README sections

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,87 @@
+# Contributing
+
+Thanks for your interest in this repo. It's primarily a personal site, but bug reports, link fixes, and accessibility improvements are welcome.
+
+## Local development
+
+### Prerequisites
+
+- R (>= 4.2). The repo pins R via `.R-version` for CI; locally any 4.2+ should work.
+- Pandoc (installed by RStudio, or via Homebrew on macOS).
+- The packages listed in `DESCRIPTION`. Install them in one shot:
+
+  ```r
+  desc <- read.dcf("DESCRIPTION")
+  pkgs <- trimws(unlist(strsplit(desc[, "Imports"], ",\\s*")))
+  install.packages(setdiff(pkgs, rownames(installed.packages())))
+  ```
+
+### Build the site
+
+```r
+rmarkdown::render_site()
+```
+
+Output goes to `_site/`. Open `_site/index.html` in a browser to preview.
+
+To render a single page (much faster during iteration):
+
+```r
+rmarkdown::render("airplane_boarding.Rmd")
+```
+
+### Google Sheets auth (CV only)
+
+The CV page reads from a Google Sheet. For local development:
+
+```r
+googlesheets4::gs4_auth()
+```
+
+CI uses a service-account key stored as the `GCP_SA_KEY` GitHub secret. Most other pages do not need auth.
+
+## Running checks locally
+
+The same checks CI runs, in increasing order of cost:
+
+```r
+# Lint a single file
+lintr::lint("scripts/generate_sitemap.R")
+
+# Lint a directory
+lintr::lint_dir("scripts/")
+
+# Run the test suite (when tests are present)
+testthat::test_dir("tests/testthat")
+```
+
+For typo / link / accessibility checks see the corresponding workflows in `.github/workflows/`. These run automatically on PR.
+
+## Pull request conventions
+
+- Branch off `origin/main`. Don't rebase published PR branches without good reason.
+- One concern per PR. Smaller PRs land faster.
+- PR titles use imperative voice (`Add ...`, `Fix ...`, `Pin ...`). No JIRA-style prefixes.
+- Reference the issue you're closing with `Closes #N` in the PR body.
+- CI must be green before merge. The data-refresh workflows don't run on PRs from forks (they need secrets); that's expected.
+
+## Adding a new page
+
+1. Create `your_page.Rmd` at the repo root.
+2. Add an entry to `_site.yml` under `navbar:` if it should appear in the top nav, or just under a `Project` card in `index.Rmd` for project pages.
+3. Render locally and confirm `pr-smoke.yml` will pick it up (it auto-discovers changed top-level `.Rmd` files).
+4. If the page needs a scheduled data refresh, add a workflow under `.github/workflows/update_*.yml` modeled on the existing ones.
+
+## Adding a new test
+
+1. Pure functions go in a sourceable file under `scripts/`.
+2. Tests go in `tests/testthat/test-<name>.R` and `source("../../scripts/<file>.R")` at the top.
+3. Run `testthat::test_dir("tests/testthat")` locally before pushing.
+
+## Reporting issues
+
+Open an issue with:
+
+- What page or workflow is affected
+- What you expected vs. what happened
+- A link to the relevant page or commit if applicable

--- a/README.Rmd
+++ b/README.Rmd
@@ -326,44 +326,7 @@ cat(sprintf(
 
 ## Setup and Local Development
 
-This website is built using R Markdown and deployed via GitHub Actions to GitHub Pages.
-
-### Prerequisites
-
-- R (>= 4.2)
-- R packages listed in `DESCRIPTION`
-- Pandoc (installed automatically by GitHub Actions, or via RStudio)
-
-### Local Development
-
-1. Clone the repository:
-   ```bash
-   git clone https://github.com/cavandonohoe/cavandonohoe.github.io.git
-   cd cavandonohoe.github.io
-   ```
-
-2. Install R dependencies:
-   ```r
-   install.packages(c("rmarkdown", "knitr", "tidyverse", "rvest", "xml2", 
-                     "httr2", "curl", "DT", "scales", "plotly", "glue", 
-                     "here", "readxl", "googlesheets4", "ggplot2", 
-                     "RColorBrewer", "pagedown", "lubridate", "patchwork"))
-   ```
-
-3. Set up Google Sheets authentication (for CV):
-   - The site uses Google Sheets API for the CV
-   - For local development, authenticate using `googlesheets4::gs4_auth()`
-   - For CI/CD, a service account key is used (stored as GitHub secret)
-
-4. Build the site locally:
-   ```r
-   rmarkdown::render_site()
-   ```
-   The site will be built in the `_site/` directory.
-
-5. Preview locally:
-   - Open `_site/index.html` in a browser, or
-   - Use RStudio's "Preview" feature
+Local development, prerequisites, build steps, lint/test commands, and PR conventions all live in [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ### Project Structure
 
@@ -379,14 +342,4 @@ This website is built using R Markdown and deployed via GitHub Actions to GitHub
 
 ### Deployment
 
-The site is automatically deployed to GitHub Pages via GitHub Actions when changes are pushed to the `main` branch. The workflow:
-
-1. Sets up R and dependencies
-2. Validates package dependencies
-3. Authenticates with Google APIs using service account
-4. Renders the R Markdown site
-5. Deploys to GitHub Pages
-
-### Contributing
-
-If you find issues or have suggestions, please open an issue or submit a pull request!
+The site is automatically deployed to GitHub Pages via GitHub Actions when changes are pushed to the `main` branch. See the Automation section above for the full list of workflows.

--- a/README.md
+++ b/README.md
@@ -128,57 +128,13 @@ above. Regenerated each time `README.Rmd` is knit.
 
 <img src="images/readme/commit-activity-cumulative-1.png" alt="Two cumulative line charts showing total commits and total lines changed (insertions + deletions) over time, split by Cavan's own commits vs. scheduled-bot commits."  />
 
-*513 commits since Dec 2020 — 491 by me, 22 by scheduled bots — touching
-1,993,711 lines in total.*
+*529 commits since Dec 2020 — 500 by me, 29 by scheduled bots — touching
+2,051,012 lines in total.*
 
 ## Setup and Local Development
 
-This website is built using R Markdown and deployed via GitHub Actions
-to GitHub Pages.
-
-### Prerequisites
-
-- R (\>= 4.2)
-- R packages listed in `DESCRIPTION`
-- Pandoc (installed automatically by GitHub Actions, or via RStudio)
-
-### Local Development
-
-1.  Clone the repository:
-
-    ``` bash
-    git clone https://github.com/cavandonohoe/cavandonohoe.github.io.git
-    cd cavandonohoe.github.io
-    ```
-
-2.  Install R dependencies:
-
-    ``` r
-    install.packages(c("rmarkdown", "knitr", "tidyverse", "rvest", "xml2", 
-                      "httr2", "curl", "DT", "scales", "plotly", "glue", 
-                      "here", "readxl", "googlesheets4", "ggplot2", 
-                      "RColorBrewer", "pagedown", "lubridate", "patchwork"))
-    ```
-
-3.  Set up Google Sheets authentication (for CV):
-
-    - The site uses Google Sheets API for the CV
-    - For local development, authenticate using
-      `googlesheets4::gs4_auth()`
-    - For CI/CD, a service account key is used (stored as GitHub secret)
-
-4.  Build the site locally:
-
-    ``` r
-    rmarkdown::render_site()
-    ```
-
-    The site will be built in the `_site/` directory.
-
-5.  Preview locally:
-
-    - Open `_site/index.html` in a browser, or
-    - Use RStudio’s “Preview” feature
+Local development, prerequisites, build steps, lint/test commands, and
+PR conventions all live in [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ### Project Structure
 
@@ -195,15 +151,5 @@ to GitHub Pages.
 ### Deployment
 
 The site is automatically deployed to GitHub Pages via GitHub Actions
-when changes are pushed to the `main` branch. The workflow:
-
-1.  Sets up R and dependencies
-2.  Validates package dependencies
-3.  Authenticates with Google APIs using service account
-4.  Renders the R Markdown site
-5.  Deploys to GitHub Pages
-
-### Contributing
-
-If you find issues or have suggestions, please open an issue or submit a
-pull request!
+when changes are pushed to the `main` branch. See the Automation section
+above for the full list of workflows.


### PR DESCRIPTION
Closes #98.

## What

- Adds \`CONTRIBUTING.md\` covering prerequisites, build steps, local lint/test commands, PR conventions, how to add a new page, and how to report issues.
- README's \"Setup and Local Development\" subsections (Prerequisites, Local Development, the multi-step contributor walkthrough, and the bare-bones Contributing section) are replaced with a pointer to \`CONTRIBUTING.md\`.
- README's \"Project Structure\" and \"Deployment\" stay in the README since they describe the codebase rather than the contributor workflow.
- Re-renders \`README.md\` from \`README.Rmd\`. The commit-activity summary text refreshed (513 -> 529 commits) since the chunk reads \`git log\` at render time; that's the expected behavior of the existing chunk.

## Why not also add a 'Repo tour' table

#98 asked for a repo-tour table listing every workflow with a one-line description. That **already exists** in the README's \"Automation\" section (the \`Site build & previews\` / \`Data refreshes\` / \`Site health\` / \`Code quality\` / \`Repo hygiene\` subsections, lines 65-118 in current \`README.md\`). Re-listing it would be duplication.

## Test plan

- [x] \`CONTRIBUTING.md\` renders correctly on GitHub
- [x] Re-render of README.Rmd is clean (only the commit-activity summary line and the two replaced sections diff)
- [ ] CI checks green