### PR TITLE
ci: grant actions:write to IMDb workflow so site redeploy dispatch works

### DIFF
--- a/.github/workflows/update_imdb_ratings.yml
+++ b/.github/workflows/update_imdb_ratings.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  actions: write
 
 # Don't pile up overlapping runs; if a previous run is still going, queue this
 # one and run it after.


### PR DESCRIPTION
## Summary

The `Update IMDb episode ratings` workflow's last step calls

```sh
gh workflow run pages-branch-previews.yml --ref main
```

to trigger a site rebuild — pushes attributed to `github-actions[bot]` via `GITHUB_TOKEN` don't trigger downstream workflows (GitHub's anti-recursion guard).

That `gh workflow run` call requires the `actions: write` permission on `GITHUB_TOKEN`, which the workflow doesn't declare. So the dispatch returns:

```
HTTP 403: Resource not accessible by integration
```

and the whole run is marked failed even though the scrape, commit, and push to `main` all succeeded.

This adds `actions: write` to the workflow's `permissions` block.

## Failures this fixes

- 2026-06-15
- 2026-06-22 (run 27957369249)

## Test plan

- [ ] After merge, manual `workflow_dispatch` of `Update IMDb episode ratings` should complete green
- [ ] The dispatched `pages-branch-previews.yml` run should also appear and succeed