### PR TITLE
Use moai emoji for Confederate Statues Timeline card

### DIFF
--- a/index.Rmd
+++ b/index.Rmd
@@ -73,7 +73,7 @@ cards <- list(
     "Fractal geometry generated in R — the classic chaos game visualization."),
   list("airplane_boarding.html", "\U2708\UFE0F", "Airplane Boarding Simulation",
     "Animated head-to-head race of Steffen, WILMA, Back-to-Front, Reverse Pyramid, and Random."),
-  list("confederate_statues.html", "\U0001F5FD", "Confederate Statues Timeline",
+  list("confederate_statues.html", "\U0001F5FF", "Confederate Statues Timeline",
     "When were Confederate monuments erected? A data-driven look at the timeline."),
   list("learn_r.html", "\U0001F4DA", "Learn R",
     "Tutorial series: intro, data manipulation, visualization, and statistics in R.")


### PR DESCRIPTION
## Summary
- Swap the index card emoji for the Confederate Statues Timeline from 🗽 (Statue of Liberty) to 🗿 (moai) — a more fitting choice for the topic.

## Test plan
- [ ] Rebuild the site locally and confirm the index card shows 🗿