### PR TITLE
Disable renv autoloader in movie-ranker personal CSV workflow

### DIFF
--- a/.github/workflows/update_movie_ranker_personal.yml
+++ b/.github/workflows/update_movie_ranker_personal.yml
@@ -40,6 +40,12 @@ jobs:
     env:
       MOVIE_RANKER_SUPABASE_URL: ${{ secrets.MOVIE_RANKER_SUPABASE_URL }}
       MOVIE_RANKER_SUPABASE_SERVICE_KEY: ${{ secrets.MOVIE_RANKER_SUPABASE_SERVICE_KEY }}
+      # The repo .Rprofile sources renv/activate.R, which switches .libPaths()
+      # to an empty renv project library and breaks `library(dplyr)` here. This
+      # workflow intentionally manages its own packages via the cache step
+      # below (see #107), so disable the renv autoloader for every Rscript
+      # call in this job.
+      RENV_CONFIG_AUTOLOADER_ENABLED: "FALSE"
     steps:
       # rocker/r-ver doesn't ship git, but actions/checkout needs it for a
       # full clone. Install just git here; everything else (curl, R, build


### PR DESCRIPTION
## Summary

Fixes the failing [Update movie-ranker personal CSV run](https://github.com/cavandonohoe/cavandonohoe.github.io/actions/runs/28037621941/job/82995123570):

```
Error in library(dplyr) : there is no package called 'dplyr'
```

The repo-level `.Rprofile` added in #107 sources `renv/activate.R`, which switches `.libPaths()` to an empty `renv/library/...` project library. This workflow intentionally does not use renv (#107 also documented that it was "intentionally left alone") — it runs in `rocker/r-ver:4.4` with its own actions-cached site-library and a small `install.packages()` step. With renv active, `library(dplyr)` couldn't find dplyr in the renv project library.

Setting `RENV_CONFIG_AUTOLOADER_ENABLED=FALSE` at the job level makes `renv/activate.R` no-op for every `Rscript` call in this job, so the cached `/usr/local/lib/R/site-library` is used as before.

## Test plan

- [ ] Manually dispatch `Update movie-ranker personal CSV` against this branch and confirm it succeeds
- [ ] After merge, confirm the next scheduled (or manually dispatched) run on `main` is green