### PR TITLE
ci: restore 6h movie-ranker cadence and daily pages-rmarkdown cron

### DIFF
--- a/.github/workflows/pages-rmarkdown.yml
+++ b/.github/workflows/pages-rmarkdown.yml
@@ -3,16 +3,16 @@ name: Build R Markdown site (sanity check)
 # NOTE: Deployment to GitHub Pages is handled by
 # pages-branch-previews.yml, which pushes to the gh-pages branch.
 # This workflow is kept as a safety-net build (DESCRIPTION checks,
-# library() validation, gs4 guards) on push-to-main. Running both
-# workflows' deploys on the same push to main caused a Pages
+# library() validation, gs4 guards, daily scheduled render). Running
+# both workflows' deploys on the same push to main caused a Pages
 # deployment race ("Deployment request failed ... due to in progress
-# deployment"), so this one no longer deploys. No cron schedule: a
-# nightly rebuild of unchanged content is pure Actions burn; use
-# workflow_dispatch for on-demand rebuilds.
+# deployment"), so this one no longer deploys.
 on:
   push:
     branches: ["main"]
   workflow_dispatch:
+  schedule:
+    - cron: "11 12 * * *" # Daily 12:11 UTC (~5:11am Pacific daylight time)
 
 permissions:
   contents: read

--- a/.github/workflows/update_movie_ranker_personal.yml
+++ b/.github/workflows/update_movie_ranker_personal.yml
@@ -5,14 +5,13 @@ name: Update movie-ranker personal CSV
 # IMDb watchlist so each rating bucket can be sorted by personal Elo instead
 # of falling back to IMDb's average.
 #
-# Runs daily; the file only changes when comparisons or overrides are recorded
-# in the app, so a daily cadence keeps the site fresh without burning Actions
-# minutes on no-op runs. Use workflow_dispatch for on-demand refreshes.
+# The file changes whenever a comparison or manual override is recorded in
+# the app, so we run on a 6h cadence plus on-demand dispatch.
 
 on:
   workflow_dispatch:
   schedule:
-    - cron: "37 12 * * *" # daily 12:37 UTC (~5:37am Pacific daylight)
+    - cron: "37 */6 * * *" # every 6 hours at :37
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary

Reverts the cadence cuts from #109. The premise of that PR ("trim Actions minutes") was wrong: this repo is public, and Actions on standard runners are free and unlimited for public repos. The "metered usage" figure on the billing dashboard is the retail \$ value of consumed compute, fully discounted to \$0 every month.

- Restore `update_movie_ranker_personal` cadence: daily → every 6 hours
- Restore `pages-rmarkdown` daily safety-net cron

The renv autoloader fix from #110 (the real reason #109's job was failing) stays in place — this only touches the cron expressions and comments.

## Test plan

- [x] `actionlint` passes on both files
- [ ] After merge: confirm next 6-hour movie-ranker run succeeds
- [ ] Confirm next daily pages-rmarkdown run succeeds