### PR TITLE
Bump listenv to 1.0.0 in renv.lock

### DIFF
--- a/renv.lock
+++ b/renv.lock
@@ -3759,7 +3759,7 @@
     },
     "listenv": {
       "Package": "listenv",
-      "Version": "0.10.1",
+      "Version": "1.0.0",
       "Source": "Repository",
       "Depends": [
         "R (>= 3.1.2)"


### PR DESCRIPTION
## Summary

- Bumps `listenv` from `0.10.1` to `1.0.0` in `renv.lock` to unblock the `Update movie-ranker personal CSV` workflow.
- CRAN released `listenv 1.0.0` on 2026-06-22. Posit Package Manager's `latest` snapshot now only serves the new version, so `renv::restore()` cannot find a binary for the pinned `0.10.1` against R 4.6.1 and silently skips it. Thirteen transitive dependents then cascade with `dependency failed`: `future`, `future.apply`, `furrr`, `polite`, `robotstxt`, `tidyquant`, `ipred`, `lava`, `prodlim`, `recipes`, `rsample`, `timetk`, `tsfeatures`.
- `listenv 1.0.0` keeps the same `Depends` (`R (>= 3.1.2)`) and `Suggests`, so no other lockfile changes are required.

Failing runs that prompted this:
- [run 28162044999](https://github.com/cavandonohoe/cavandonohoe.github.io/actions/runs/28162044999)
- [run 28147549153](https://github.com/cavandonohoe/cavandonohoe.github.io/actions/runs/28147549153)

## Test plan

- [ ] CI: `Build R Markdown site (sanity check)` passes (exercises `setup-renv`).
- [ ] CI: `Build site + deploy prod & PR previews` passes.
- [ ] After merge, the next scheduled `Update movie-ranker personal CSV` run succeeds.