### PR TITLE
Grant actions: write to data refresh workflows

### DIFF
--- a/.github/workflows/refresh-sitemap.yml
+++ b/.github/workflows/refresh-sitemap.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  actions: write
 
 concurrency:
   group: refresh-sitemap

--- a/.github/workflows/update_director_filmographies.yml
+++ b/.github/workflows/update_director_filmographies.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: write
+  actions: write
 
 concurrency:
   group: refresh-director-filmographies

--- a/.github/workflows/update_sp500.yml
+++ b/.github/workflows/update_sp500.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  actions: write
 
 concurrency:
   group: refresh-sp500


### PR DESCRIPTION
## Summary

- Adds `actions: write` to three scheduled workflows that dispatch `pages-branch-previews.yml` as a final step:
  - `.github/workflows/refresh-sitemap.yml`
  - `.github/workflows/update_sp500.yml`
  - `.github/workflows/update_director_filmographies.yml`
- Without it, the `gh workflow run pages-branch-previews.yml --ref main` step fails with `HTTP 403: Resource not accessible by integration` and the entire run is marked failed even though the data refresh itself succeeded.
- Same fix that landed in [#104](https://github.com/cavandonohoe/cavandonohoe.github.io/pull/104) for the IMDb workflow and is already in place on `update_movie_ranker_personal.yml`.

Failing runs that prompted this:
- Refresh sitemap.xml: [run 27908962932](https://github.com/cavandonohoe/cavandonohoe.github.io/actions/runs/27908962932)
- Refresh S&P 500 (VOO) data: [run 27875302013](https://github.com/cavandonohoe/cavandonohoe.github.io/actions/runs/27875302013)
- Refresh director filmographies (TMDb): [run 27706854149](https://github.com/cavandonohoe/cavandonohoe.github.io/actions/runs/27706854149)

The second commit on this branch removes an accidentally-added `food-ranker` submodule reference (a stray local directory picked up by `git add -A`).

## Test plan

- [ ] Manually dispatch each of the three workflows after merge and confirm they end with the redeploy step succeeding (not 403).