### PR TITLE
Add Virginia to confederate statues sources list

### DIFF
--- a/confederate_statues.Rmd
+++ b/confederate_statues.Rmd
@@ -126,6 +126,7 @@ https://en.wikipedia.org/wiki/List_of_Confederate_monuments_and_memorials_in_Geo
 https://en.wikipedia.org/wiki/List_of_Confederate_monuments_and_memorials_in_Mississippi
 https://en.wikipedia.org/wiki/List_of_Confederate_monuments_and_memorials_in_North_Carolina
 https://en.wikipedia.org/wiki/List_of_Confederate_monuments_and_memorials_in_South_Carolina
+https://en.wikipedia.org/wiki/List_of_Confederate_monuments_and_memorials_in_Virginia
 https://en.wikipedia.org/wiki/List_of_Confederate_monuments_and_memorials
 
 


### PR DESCRIPTION
## Summary

Virginia was added as a dedicated Wikipedia source in the [`confederate_statues`](https://github.com/cavandonohoe/confederate_statues) data pipeline. The chart and the peak-year sentence on this page already update automatically (they read the CSV live from that repo's `main` and compute the peak dynamically), but the **sources list** at the bottom of `confederate_statues.Rmd` is hardcoded and still listed only the original six pages.

This adds the Virginia link so the page's citations match the underlying dataset.

## Test plan

- [x] Bare URL line, consistent with the surrounding source links
- [ ] Site build renders `confederate_statues.html` with Virginia in the sources list