### PR TITLE
Fix best-picture oscar_year: derive ceremony year instead of row order

### DIFF
--- a/data/best_picture_winners.csv
+++ b/data/best_picture_winners.csv
@@ -91,8 +91,8 @@ rank,oscar_titles,movie_year,oscar_imdb_ratings,oscar_imdb_id,tconst,life_time_g
 90,Mutiny on the Bounty,1935,7.6,https://www.imdb.com/title/tt0026752/,tt0026752,4901,1936
 91,It Happened One Night,1934,8.1,https://www.imdb.com/title/tt0025316/,tt0025316,16993,1935
 92,Cavalcade,1933,5.8,https://www.imdb.com/title/tt0023876/,tt0023876,NA,1934
-93,Grand Hotel,1932,7.3,https://www.imdb.com/title/tt0022958/,tt0022958,1130,1933
-94,Cimarron,1931,5.8,https://www.imdb.com/title/tt0021746/,tt0021746,NA,1932
-95,All Quiet on the Western Front,1930,8.1,https://www.imdb.com/title/tt0020629/,tt0020629,466,1931
+93,Grand Hotel,1932,7.3,https://www.imdb.com/title/tt0022958/,tt0022958,1130,1932
+94,Cimarron,1931,5.8,https://www.imdb.com/title/tt0021746/,tt0021746,NA,1931
+95,All Quiet on the Western Front,1930,8.1,https://www.imdb.com/title/tt0020629/,tt0020629,466,1930
 96,The Broadway Melody,1929,5.5,https://www.imdb.com/title/tt0019729/,tt0019729,NA,1930
 98,Wings,1927,7.5,https://www.imdb.com/title/tt0018578/,tt0018578,1684,1929

--- a/data/best_picture_winners.csv
+++ b/data/best_picture_winners.csv
@@ -19,7 +19,7 @@ rank,oscar_titles,movie_year,oscar_imdb_ratings,oscar_imdb_id,tconst,life_time_g
 18,No Country for Old Men,2007,8.2,https://www.imdb.com/title/tt0477348/,tt0477348,171635732,2008
 19,The Departed,2006,8.5,https://www.imdb.com/title/tt0407887/,tt0407887,292095942,2007
 20,Million Dollar Baby,2004,8.1,https://www.imdb.com/title/tt0405159/,tt0405159,216763646,2005
-21,Crash,2004,7.7,https://www.imdb.com/title/tt0375679/,tt0375679,98410061,2005
+21,Crash,2004,7.7,https://www.imdb.com/title/tt0375679/,tt0375679,98410061,2006
 22,The Lord of the Rings: The Return of the King,2003,9,https://www.imdb.com/title/tt0167260/,tt0167260,1139431705,2004
 23,Chicago,2002,7.2,https://www.imdb.com/title/tt0299658/,tt0299658,306777683,2003
 24,A Beautiful Mind,2001,8.2,https://www.imdb.com/title/tt0268978/,tt0268978,316791257,2002

--- a/web_scraping/best_picture_winners.R
+++ b/web_scraping/best_picture_winners.R
@@ -142,30 +142,68 @@ if (use_cache) {
 # clean it up
 #
 # The ceremony year (oscar_year) is the calendar year in which the Academy
-# Awards ceremony was held. A film released in year N is honored at the
-# ceremony held in year N + 1, so oscar_year = movie_year + 1 for the vast
-# majority of winners. A handful of films carry an IMDb releaseYear that does
-# not match their Academy eligibility year (early festival premieres, the
-# 1927/28 combined first ceremony, the shifted early-1940s eligibility window),
-# so those ceremony years are corrected explicitly, keyed by IMDb title id
-# (tconst) rather than the display title (which can drift, e.g. "Crash (I)").
-oscar_year_overrides <- tibble::tribble(
-  ~tconst,     ~oscar_year_fixed,
-  "tt0018578", 1929L,  # Wings (movie 1927; 1st ceremony honored 1927/28)
-  "tt0034583", 1944L,  # Casablanca (movie 1942; 16th ceremony, 1943 films)
-  "tt0375679", 2006L,  # Crash (movie 2004; 78th ceremony, 2005 films)
-  "tt0887912", 2010L   # The Hurt Locker (movie 2008; 82nd ceremony, 2009 films)
+# Awards ceremony was held. We source it from Wikidata rather than deriving it,
+# because the release-year -> ceremony-year mapping has real exceptions that
+# no simple rule captures: films whose IMDb releaseYear precedes their
+# eligibility year (Casablanca, Crash, The Hurt Locker), the early
+# non-calendar-year ceremonies (1930-1932), the two ceremonies held in 1930,
+# and the skipped 1933 ceremony. Wikidata's "point in time" (P585) qualifier
+# on the Best Picture award statement records the actual ceremony year, keyed
+# to the film's IMDb id (P345), which joins cleanly to our scraped tconst.
+fetch_oscar_years_wikidata <- function() {
+  query <- paste(
+    "SELECT ?imdb ?ceremony_year WHERE {",
+    "  ?film p:P166 ?statement .",
+    "  ?statement ps:P166 wd:Q102427 .",
+    "  ?statement pq:P585 ?date .",
+    "  BIND(YEAR(?date) AS ?ceremony_year)",
+    "  ?film wdt:P345 ?imdb .",
+    "}",
+    sep = "\n"
+  )
+  response <- httr::GET(
+    "https://query.wikidata.org/sparql",
+    query = list(query = query, format = "json"),
+    httr::user_agent(imdb_user_agent),
+    httr::timeout(60)
+  )
+  if (httr::http_error(response)) {
+    stop("Wikidata SPARQL request failed: HTTP ", httr::status_code(response))
+  }
+  parsed <- jsonlite::fromJSON(
+    httr::content(response, as = "text", encoding = "UTF-8"),
+    simplifyVector = TRUE
+  )
+  bindings <- parsed$results$bindings
+  tibble::tibble(
+    tconst = bindings$imdb$value,
+    oscar_year = as.integer(bindings$ceremony_year$value)
+  ) %>%
+    # keep films only (P345 also resolves to producer name-ids like nm...)
+    dplyr::filter(grepl("^tt", .data$tconst)) %>%
+    # one ceremony year per film
+    dplyr::group_by(.data$tconst) %>%
+    dplyr::summarise(oscar_year = min(.data$oscar_year), .groups = "drop")
+}
+
+oscar_years <- tryCatch(
+  fetch_oscar_years_wikidata(),
+  error = function(err) {
+    message("[best_picture] Wikidata lookup failed (", conditionMessage(err),
+            "); falling back to movie_year + 1.")
+    tibble::tibble(tconst = character(0), oscar_year = integer(0))
+  }
 )
 
 oscar_winners_clean <- oscar_winners_tib %>%
   dplyr::bind_cols(oscar_box_office) %>%
   # doesn't actually look like Sunrise won the oscar
   dplyr::filter(oscar_titles != "Sunrise") %>%
-  dplyr::left_join(oscar_year_overrides, by = "tconst") %>%
+  dplyr::left_join(oscar_years, by = "tconst") %>%
+  # fall back to release year + 1 for any winner Wikidata doesn't yet have
   dplyr::mutate(
-    oscar_year = dplyr::coalesce(.data$oscar_year_fixed, .data$movie_year + 1L)
-  ) %>%
-  dplyr::select(-"oscar_year_fixed")
+    oscar_year = dplyr::coalesce(.data$oscar_year, .data$movie_year + 1L)
+  )
 
 # oscar_winners_clean %>% write.csv(here::here("data", "best_picture_winners.csv"))
 

--- a/web_scraping/best_picture_winners.R
+++ b/web_scraping/best_picture_winners.R
@@ -140,20 +140,32 @@ if (use_cache) {
 }
 
 # clean it up
-latest_oscar_year <- max(oscar_winners_tib$movie_year, na.rm = TRUE) + 1
+#
+# The ceremony year (oscar_year) is the calendar year in which the Academy
+# Awards ceremony was held. A film released in year N is honored at the
+# ceremony held in year N + 1, so oscar_year = movie_year + 1 for the vast
+# majority of winners. A handful of films carry an IMDb releaseYear that does
+# not match their Academy eligibility year (early festival premieres, the
+# 1927/28 combined first ceremony, the shifted early-1940s eligibility window),
+# so those ceremony years are corrected explicitly, keyed by IMDb title id
+# (tconst) rather than the display title (which can drift, e.g. "Crash (I)").
+oscar_year_overrides <- tibble::tribble(
+  ~tconst,     ~oscar_year_fixed,
+  "tt0018578", 1929L,  # Wings (movie 1927; 1st ceremony honored 1927/28)
+  "tt0034583", 1944L,  # Casablanca (movie 1942; 16th ceremony, 1943 films)
+  "tt0375679", 2006L,  # Crash (movie 2004; 78th ceremony, 2005 films)
+  "tt0887912", 2010L   # The Hurt Locker (movie 2008; 82nd ceremony, 2009 films)
+)
 
 oscar_winners_clean <- oscar_winners_tib %>%
   dplyr::bind_cols(oscar_box_office) %>%
   # doesn't actually look like Sunrise won the oscar
   dplyr::filter(oscar_titles != "Sunrise") %>%
-  dplyr::mutate(oscar_year = latest_oscar_year - dplyr::row_number() + 1) %>%
-  dplyr::mutate(oscar_year = dplyr::case_when(oscar_titles == "The Hurt Locker" ~ 2010,
-                                oscar_titles == "Slumdog Millionaire" ~ 2009,
-                                oscar_titles == "Crash (I)" ~ 2006,
-                                oscar_titles == "Million Dollar Baby" ~ 2005,
-                                oscar_titles == "Mrs. Miniver" ~ 1943,
-                                oscar_titles == "Casablanca" ~ 1944,
-                                TRUE ~ oscar_year))
+  dplyr::left_join(oscar_year_overrides, by = "tconst") %>%
+  dplyr::mutate(
+    oscar_year = dplyr::coalesce(.data$oscar_year_fixed, .data$movie_year + 1L)
+  ) %>%
+  dplyr::select(-"oscar_year_fixed")
 
 # oscar_winners_clean %>% write.csv(here::here("data", "best_picture_winners.csv"))
 


### PR DESCRIPTION
## Summary

`oscar_year` in the best-picture-winners dataset was being **fabricated from IMDb sort position** (`latest_oscar_year - row_number() + 1`) rather than derived from any real ceremony-year field, with a scattered `case_when` patching the drift. This is the same class of bug as the confederate-statues scraper (a displayed field synthesized from something incidental).

The row-arithmetic + patch approach had produced a concrete data error: **two winners tagged 2005** (Crash and Million Dollar Baby) and **a missing 2006**.

## Fix

Rather than derive or hardcode the ceremony year, **source it from [Wikidata](https://www.wikidata.org/wiki/Q102427)** via a SPARQL query:

- Wikidata's `point in time` (P585) qualifier on the Best Picture award statement records the actual ceremony year.
- The film's IMDb id (P345) joins cleanly to our scraped `tconst` (100% coverage of our winners).
- `movie_year + 1` is retained only as a **fallback** if the lookup fails or a brand-new winner isn't in Wikidata yet (handled via `tryCatch`).

This removes the stale-data risk of a hardcoded table and is **strictly more accurate** — it correctly captures cases no arithmetic rule can express:

- Films whose IMDb `releaseYear` precedes their eligibility year (Casablanca, Crash, The Hurt Locker).
- The early **non-calendar-year** ceremonies: All Quiet on the Western Front (1930), Cimarron (1931), Grand Hotel (1932) — the previous logic had these a year late.
- The **two ceremonies held in 1930** (Broadway Melody + All Quiet), and the **skipped 1933** ceremony.

## Verification

- Confirmed all our winners join to Wikidata by `tconst` (no unmatched rows; fallback triggered for 0 rows).
- Spot-checked known winners against true ceremony years — all correct.
- The resulting sequence reflects the real historical ceremony structure (including the legitimate 1930 double and 1933 gap).
- Only the derived `oscar_year` column is affected; scraped fields are untouched.