### PR TITLE
ci(rentals): grant actions:write and pin R version

### DIFF
--- a/.github/workflows/update_us_rentals.yml
+++ b/.github/workflows/update_us_rentals.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  actions: write
 
 concurrency:
   group: refresh-us-rentals
@@ -22,7 +23,7 @@ jobs:
       - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true
-          r-version-file: .R-version
+          r-version: 4.6.0
 
       - name: Install system dependencies
         run: |


### PR DESCRIPTION
## Summary

The monthly [Refresh US rental markets data](https://github.com/cavandonohoe/cavandonohoe.github.io/actions/runs/28746344131) workflow failed. Root cause and fixes:

- **Redeploy step 403 (the failure):** The final `Trigger site redeploy` step ran `gh workflow run pages-branch-previews.yml` and got `HTTP 403: Resource not accessible by integration`. The job's `GITHUB_TOKEN` only had `contents: write`; dispatching a workflow requires `actions: write`. Added `actions: write` to the permissions block.
- **Invalid `setup-r` input (silent bug):** `r-lib/actions/setup-r@v2` does not accept `r-version-file`, so it was ignored and default R was installed instead of the pinned version (the run logged an "Unexpected input(s) 'r-version-file'" warning). Replaced with the valid `r-version: 4.6.0` (matches `.R-version`).

The data refresh, verify, commit, and push all succeeded in the failing run — only the downstream dispatch failed, which is what turned the job red.

## Test plan
- [ ] Manually dispatch the workflow (`workflow_dispatch`) and confirm the `Trigger site redeploy` step succeeds (no 403).
- [ ] Confirm `setup-r` installs R 4.6.0 with no "Unexpected input" warning.