### PR TITLE
chore: ignore agent tooling dirs (.positai, .claude)

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -2,3 +2,5 @@
 ^renv\.lock$
 ^.*\.Rproj$
 ^\.Rproj\.user$
+^\.positai$
+^\.claude$

--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,6 @@ Thumbs.db
 !/sitemap.xml
 # Optional: keep CNAME if you add it for Pages DNS
 # !/CNAME
+# Agent tooling directories
+.positai
+.claude


### PR DESCRIPTION
## Summary
- Add `.positai` and `.claude` (local agent tooling directories) to `.Rbuildignore` and `.gitignore` so they aren't picked up by the R package build or committed to git.

## Test plan
- [ ] Confirm `.positai` / `.claude` no longer show as untracked in `git status`.