### PR TITLE
Cache Confederate statues source data

### DIFF
--- a/.github/workflows/update_confederate_statues_data.yml
+++ b/.github/workflows/update_confederate_statues_data.yml
@@ -1,0 +1,89 @@
+name: Refresh Confederate statues data
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "17 14 1 * *" # 1st of each month, 14:17 UTC
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: refresh-confederate-statues-data
+  cancel-in-progress: false
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Fetch latest CSV
+        run: |
+          set -euo pipefail
+
+          url="https://raw.githubusercontent.com/cavandonohoe/confederate_statues/main/data/confederate_statue_dates.csv"
+          tmp="$(mktemp)"
+
+          curl \
+            --fail \
+            --show-error \
+            --silent \
+            --location \
+            --retry 4 \
+            --retry-all-errors \
+            --retry-delay 5 \
+            "$url" \
+            --output "$tmp"
+
+          python3 - "$tmp" <<'PY'
+          import csv
+          import sys
+
+          path = sys.argv[1]
+          with open(path, newline="", encoding="utf-8") as handle:
+              reader = csv.DictReader(handle)
+              rows = list(reader)
+
+          expected_fields = ["source", "entry", "year"]
+          if reader.fieldnames != expected_fields:
+              raise SystemExit(
+                  f"Unexpected CSV columns: {reader.fieldnames}. "
+                  f"Expected: {expected_fields}"
+              )
+
+          if not rows:
+              raise SystemExit("CSV contained no data rows.")
+
+          for row_number, row in enumerate(rows, start=2):
+              if not row["source"].strip():
+                  raise SystemExit(f"Missing source on row {row_number}.")
+              if not row["entry"].strip():
+                  raise SystemExit(f"Missing entry on row {row_number}.")
+              try:
+                  int(row["year"])
+              except ValueError as exc:
+                  raise SystemExit(
+                      f"Invalid year on row {row_number}: {row['year']!r}"
+                  ) from exc
+
+          print(f"Validated {len(rows)} rows.")
+          PY
+
+          mv "$tmp" data/confederate_statue_dates.csv
+
+      - name: Open PR if data changed
+        uses: peter-evans/create-pull-request@v8
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: auto/update-confederate-statue-dates
+          delete-branch: true
+          commit-message: "Update Confederate statue dates cache"
+          title: "Update Confederate statue dates cache"
+          body: |
+            This scheduled check refreshed the local Confederate statue dates cache from the upstream source repository.
+
+            Review the CSV diff before merging. Keeping this as a PR avoids changing the published site data silently from a scheduled workflow.
+          add-paths: |
+            data/confederate_statue_dates.csv

--- a/.github/workflows/update_confederate_statues_data.yml
+++ b/.github/workflows/update_confederate_statues_data.yml
@@ -7,7 +7,7 @@ on:
 
 permissions:
   contents: write
-  pull-requests: write
+  actions: write
 
 concurrency:
   group: refresh-confederate-statues-data
@@ -73,17 +73,48 @@ jobs:
 
           mv "$tmp" data/confederate_statue_dates.csv
 
-      - name: Open PR if data changed
-        uses: peter-evans/create-pull-request@v8
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          branch: auto/update-confederate-statue-dates
-          delete-branch: true
-          commit-message: "Update Confederate statue dates cache"
-          title: "Update Confederate statue dates cache"
-          body: |
-            This scheduled check refreshed the local Confederate statue dates cache from the upstream source repository.
+      - name: Verify only expected CSV changed
+        run: |
+          set -euo pipefail
+          unexpected="$(git diff --name-only HEAD \
+            | grep -Ev '^data/confederate_statue_dates\.csv$' || true)"
+          if [ -n "$unexpected" ]; then
+            echo "ERROR: refresh modified files outside data/confederate_statue_dates.csv:"
+            echo "$unexpected"
+            exit 1
+          fi
 
-            Review the CSV diff before merging. Keeping this as a PR avoids changing the published site data silently from a scheduled workflow.
-          add-paths: |
-            data/confederate_statue_dates.csv
+      - name: Commit and push if changed
+        id: push
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add data/confederate_statue_dates.csv
+
+          if git diff --cached --quiet; then
+            echo "No changes."
+            echo "pushed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          git commit -m "Update Confederate statue dates cache"
+          for i in 1 2 3; do
+            if git push; then
+              echo "pushed=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            echo "Push failed; rebasing on remote and retrying ($i/3)..."
+            git pull --rebase origin "$(git rev-parse --abbrev-ref HEAD)"
+          done
+
+          echo "ERROR: failed to push Confederate statue dates cache update after 3 attempts."
+          exit 1
+
+      # Bot pushes via GITHUB_TOKEN don't trigger downstream workflows, so
+      # explicitly dispatch the site build after updating the cache.
+      - name: Trigger site redeploy
+        if: steps.push.outputs.pushed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh workflow run pages-branch-previews.yml --ref main

--- a/confederate_statues.Rmd
+++ b/confederate_statues.Rmd
@@ -59,10 +59,10 @@ Check these out btw:
 
 
 ```{r}
-all_dates <- readr::read_csv(paste0(
-  "https://raw.githubusercontent.com/cavandonohoe/",
-  "confederate_statues/main/data/confederate_statue_dates.csv"
-))
+all_dates <- readr::read_csv(
+  "data/confederate_statue_dates.csv",
+  show_col_types = FALSE
+)
 
 # find mode
 max_statues <- all_dates %>%

--- a/data/confederate_statue_dates.csv
+++ b/data/confederate_statue_dates.csv
@@ -1,0 +1,971 @@
+"source","entry","year"
+"alabama","Bullock County (1866) named for secessionist politician and CSA Col. Edward Bullock",1866
+"alabama","City of Clanton (1866) seat of Chilton County named for CSA Brig. Gen. James H. Clanton",1866
+"alabama","Cleburne County (1866) named for CSA Maj. Gen. Patrick Cleburne",1866
+"alabama","Lee County (1866) named for Robert E. Lee.",1866
+"alabama","Hale County (1867) named for CSA Lt. Col. Stephen F. Hale; also a member of the Provisional Confederate States Congress",1867
+"alabama","Chilton County (1868) named for William Parish Chilton, judge and member of the Confederate Provisional Congress",1868
+"alabama","Mobile: Confederate Rest and Monument, Magnolia Cemetery (1874)[83]",1874
+"alabama","Confederate Dead Monument, Gainesville Cemetery (1876) Ladies Memorial Association of Gainesville[78]",1876
+"alabama","Confederate Memorial Circle (1878) Confederate Memorial Association[61]",1878
+"alabama","Camden: Confederate Monument (1880) Ladies Memorial and Wilcox Monumental Associations, Wilcox County, Alabama[78]",1880
+"alabama","Tuscaloosa: Confederate Monument, Greenwood Cemetery (1880) by the Ladies Memorial Association[85]",1880
+"alabama","Auburn: Auburn Guard Monument, Pine Hill Cemetery (1893) Ladies Memorial Association, forerunner of UDC[16]",1893
+"alabama","Union Springs: Confederate Monument, Old City Cemetery (The Confederate Cemetery) (1893) Ladies Memorial Association[88]",1893
+"alabama","Alabama State Flag (1895) The Alabama Department of Archives and History found in 1915 that the flag was meant to ""preserve in permanent form some of the more distinctive features of the Confederate battle flag, particularly the St. Andrew's cross.""[11] According to historian John M. Coski, the adoption of Alabama's flag coincided with the rise of Jim Crow laws and segregation,[12] as other former Confederate slave states, such as Mississippi and Florida, also adopted new state flags based on Confederate designs around the same time when those states instituted Jim Crow segregation laws themselves:[12]",1895
+"alabama","Boligee: Confederate Monument, Bethsalem Cemetery (1896) Ladies Memorial Association[78]",1896
+"alabama","Jefferson Davis Presidential Star, marble portico (1897).[8] ""Placed by the Sophie Bibb Chapter Daughters of the Confederacy on the Spot where Jefferson Davis Stood when Inaugurated President of the C.S.A. Feb. 18, 1861""[9]",1897
+"alabama","Confederate Memorial Monument, also known as the ""Monument to Confederate Soldiers and Sailors"" (1898).[6] On June 24, 2015, in the wake of the Charleston church shooting on June 17, 2015, on the order of Governor Robert J. Bentley, the four Confederate flags, and their poles, were removed.[7]",1898
+"alabama","Statue of Admiral Raphael Semmes, on Government Street near the Bankhead Tunnel (1900) by SCV, Raphael Semmes Camp 11[52] Removed June 5, 2020.",1900
+"alabama","Florence: Confederate Monument, Lauderdale County Courthouse (1903) Ladies Memorial Association.[24]",1903
+"alabama","Greenville: Butler County Confederate Memorial, ""Our Confederate Dead"", at Confederate Park (1903) by UDC of Butler County, Alabama, Father Ryan Chapter[44]",1903
+"alabama","Greensboro: Confederate Monument, Hale County Courthouse (1904) Ladies Memorial Association of Greensboro.",1904
+"alabama","Anniston: Major John Pelham Monument, Quintard Avenue (1905) through the efforts of Clarence J. Owens, president of Anniston College for Young Ladies.[31] Removed in 2020.[32]",1905
+"alabama","Eufaula: Confederate Monument (1905) by UDC, Barbour County Chapter[39]",1905
+"alabama","Huntsville: Confederate Soldier Memorial, erected near the Madison County Courthouse (1905) by UDC.[46] Moved to Maple Hill Cemetery in 2020.[47][48]",1905
+"alabama","Jacksonville: The Gallant Pelham Statue, Jacksonville City Cemetery (1905) by UDC, John H. Forney Chapter[49]",1905
+"alabama","Birmingham: Confederate Monument, Elmwood Cemetery (1906), UCV, Camp Hardee[16]",1906
+"alabama","Defense of Selma Memorial (1907) by UDC[61][65]",1907
+"alabama","Emma Sansom and Nathan Bedford Forrest Monument (1907) by UDC, Gadsden Chapter.[42]",1907
+"alabama","Jasper: Confederate Monument, Walker County Courthouse (1907) Jasper County Chapter 925 by UDC.[25]",1907
+"alabama","Confederate Monument, City Hall Square (1908) by UDC[61]",1908
+"alabama","Livingston: Confederate Monument, Sumter County Courthouse (1908) by UDC, Sumter Chapter.[26]",1908
+"alabama","Robert E. Lee statue, Robert E. Lee High School (1908)[55]",1908
+"alabama","Troy: ""Comrades"" Confederate Monument (1908) Pike Monumental Association, UCV, and UDC of Pike County, Alabama[75]",1908
+"alabama","Athens: Limestone County Confederate Soldiers Memorial, Athens City Cemetery (1909) by UDC, Joseph E. Johnston Chapter",1909
+"alabama","Clayton: Confederate Monument (1909); UDC monument at Barbour County Courthouse Square.[21]",1909
+"alabama","Jacksonville: Confederate Monument, Jacksonville Town Square (1909). Bears a quote from Jefferson Davis: ""Let none of the survivors of these men offer in their behalf the penitential plea, 'They believed they were right.' Be it ours to transmit to posterity our unequivocal confidence in the righteousness of the cause for which these men died.""[49]",1909
+"alabama","Centreville: Confederate Monument, Bibb County Courthouse (1910) by UDC, Leonard Calloway Pratt Chapter No. 1056.[20]",1910
+"alabama","Confederate Monument (1910). The statue was toppled on July 16, 2016 when a policeman accidentally crashed his patrol car into the monument; the statue fell from its pedestal and was heavily damaged. In 2017, the Demopolis city council voted 3–2 to move the damaged Confederate statue to a local museum and to install a new obelisk memorial that honors both the Union and the Confederate soldiers.[36][37]",1910
+"alabama","Greenville: Confederate Park (1910)",1910
+"alabama","Ozark: Dale County Confederate Soldiers Monument (1910) Stonewall Jackson Chapter by UDC No. 667 of Dale County, Alabama",1910
+"alabama","Sidney Lanier High School (1910)",1910
+"alabama","Opelika: Confederate Monument (1911) by UDC, Robert E. Lee Chapter[57]",1911
+"alabama","Tuscumbia: Confederate Veterans Monument, Colbert County Courthouse (1911) by UDC, Tuscumbia Chapter.[30]",1911
+"alabama","Fort Payne: Confederate Monument (1913) by UDC and SCV of DeKalb County, Alabama[41]",1913
+"alabama","Millbrook: Robinson Springs Camp Confederate Monument (1913) by UCV Camp No. 396, Elmore County, Alabama[51]",1913
+"alabama","Birmingham: Confederacy Rock, University of Alabama, (1914) by UDC Alabama Division, to commemorate University of Alabama students who served in the Confederate Army. The Board of Trustees of The University of Alabama ordered the Rock and its plaques removed on June 15, 2020.[33][34]",1914
+"alabama","Munford: A. J. Buttram Monument (1914) by UDC, John Tyler Morgan Chapter[56]",1914
+"alabama","Tuscaloosa: University of Alabama Civil War Memorial, South entrance of the University of Alabama's Amelia Gayle Gorgas Library (1914) by UDC, Alabama Division[76]",1914
+"alabama","UDC monument (1916) to Prattville Dragoons, on grounds of Prattville Primary School[62]",1916
+"alabama","Memorial boulder marking The Selma Ordnance and Naval Foundry ""destroyed by the Federals 1865,"" placed ""in honor of the memory of hundreds of faithful men who made these great works a base for war material for the entire Confederate Army and Navy."" (1917) Alabama Division United Daughters of Confederacy.[66]",1917
+"alabama","Athens: Limestone County Confederate Soldiers Memorial, Limestone County Courthouse (1922) by United Confederate Veterans (UCV) and UDC.[16]",1922
+"alabama","Decatur: Confederate Monument, near Morgan County Courthouse (1922) by UDC, Joe Wheeler Chapter No. 291.[22]",1922
+"alabama","Alabama Coat of Arms (1923) and the State Seal include the Confederate Battle Flag.",1923
+"alabama","Ashville: Confederate Soldiers of Ashville Monument, St. Clair County Courthouse (1923) by United Daughters of the Confederacy, (UDC) Ashville Chapter.[15]",1923
+"alabama","Beauregard High School (1923)",1923
+"alabama","Forrest Confederate Monument (1923) by UDC[82]",1923
+"alabama","Carrollton: Confederate War Memorial, Pickens County Courthouse (1927).[18]",1927
+"alabama","Fayette: Confederate Monument, Fayette County Courthouse (1929) by UDC, Fayette Chapter.[23]",1929
+"alabama","Lowndesboro: Our Confederate Soldiers Monument (1929) by the Lowndesboro Chapter of UDC of Lowndes County, Alabama.",1929
+"alabama","""Arsenal Place"" memorial (1931), marking the site of the Confederate ordnance works ""destroyed by the Union Army April 6, 1865""",1931
+"alabama","Butler: Confederate Monument, Choctaw County Courthouse (1936) by UDC, Choctaw Ruffin Dragoon Chapter.[17]",1936
+"alabama","Headland: Henry County Confederate Memorial (1936) by UDC, Headland Chapter No. 1673[45]",1936
+"alabama","Confederate Fortification Monument (1940), Mobile National Cemetery[53]",1940
+"alabama","Jefferson Davis (1940), by UDC[10]",1940
+"alabama","The Edmund Pettus Bridge (1940), on US Route 80, is named for Edmund Pettus, Confederate General and Alabama Grand Dragon of the KKK.[64] This is the beginning of the Selma to Montgomery National Historic Trail (1996), commemorating the Selma to Montgomery civil rights marches of 1965.",1940
+"alabama","Breastworks Confederate Memorial (1941)",1941
+"alabama","UDC monument (1942) on Dexter Avenue: ""Along this street moved the inaugural parade of Jefferson Davis when he took the oath of office as President of the Confederate States of America February 18, 1861. Dixie was played as a band arrangement for the first time on this occasion.""[54]",1942
+"alabama","Rogersville: Joe Wheeler State Park (1949) beside Wheeler Lake and Wheeler Dam all named for Confederate General and U.S. Congressman Joseph Wheeler",1949
+"alabama","Huntsville: Lee High School (1957), home to the Lee Generals[93]",1957
+"alabama","Confederate Memorial Marker at corner of Hwy 82 and Main Street in honour of Midway Guards prior drill grounds erected by UDC (1960)[50]",1960
+"alabama","Jefferson Davis High School (1968)",1968
+"alabama","Hamilton: Confederate Veterans Bicentennial Memorial (1977)",1977
+"alabama","Tuscaloosa County: UDC monument (1977) at Tannehill Ironworks, where Confederate munitions and iron were manufactured[77]",1977
+"alabama","Centre: Confederate Memorial, Cherokee County Courthouse (1988) by SCV, Emma Sansom Camp No. 27.[19]",1988
+"alabama","Turkey Town Monument (1992) by SCV, Turkey Town Valley Camp #1512[43]",1992
+"alabama","The Edmund Pettus Bridge (1940), on US Route 80, is named for Edmund Pettus, Confederate General and Alabama Grand Dragon of the KKK.[64] This is the beginning of the Selma to Montgomery National Historic Trail (1996), commemorating the Selma to Montgomery civil rights marches of 1965.",1996
+"alabama","The Nathan Bedford Forrest Bust Monument (2000). Built partly with city funds, sponsored by Friends of Forrest and UDC. It was first located at the Vaughan-Smitherman Museum, but during protest over Forrest's KKK links trash was dumped on it[67] and it was damaged during an apparent attempt to remove the bust from its foundation. It was then moved to the Cemetery's Confederate Circle. The bust was then stolen in 2012[68] and has not been recovered, despite a $20,000 reward; the present bust is a replacement.[69] The base is inscribed, under a Confederate flag: ""Defender of Selma, Wizard of the Saddle, untutored genius, the first with the most. This monument stands as testament of our perpetual devotion and respect to Lt. Gen. Nathan Bedford Forrest, C.S.A., 1821-1877, one of the South's finest heroes. In honor of Gen. Forrest's unwavering defense of Selma, the great state of Alabama, and the Confederacy, this memorial is dedicated. Deo vindice.""[70][71]",2000
+"alabama","Beauregard Elementary School (2001) new campus on Lee County Rd 300 constructed, previously shared location with high school[94]",2001
+"alabama","Ohatchee: Calhoun County Confederate Memorial (2003) at Janney Furnace Park, ""the world's largest black granite Confederate Memorial""[59][60]",2003
+"alabama","Moulton: Confederate Monument, Lawrence County Courthouse (2006) by SCV, Lt. J. K. McBride Camp No. 241 and the Alabama Division.[29]",2006
+"alabama","Rogersville: CSA Gen. Joseph Wheeler Monument, Joe Wheeler State Park (2006) by SCV, Freeman's Battery Forrest's Artillery Camp No. 1939[63]",2006
+"alabama","Blakeley: UDC monument (2010) at Historic Blakeley State Park dedicated to Confederate soldiers and sailors who served at Fort Blakeley[35]",2010
+"georgia","Blakely: Confederate Flagpole, Early County Courthouse (1861)[15]",1861
+"georgia","Peachtree Battle Avenue Monument (1935), a stone-engraved memorial commemorating the Battle of Peachtree Creek (1864). Because state law prohibits its removal, a panel was added in 2019 saying: ""[The monument] describes the United States after the civil war as a perfected nation. This ignores the segregation and disenfranchisement of African Americans and others that still existed in 1935.""[12]",1864
+"georgia","Athens: Athens Confederate Monument (1872)[38]",1872
+"georgia","Confederate Reunion Memorial, along city sidewalk (1874).[98]",1874
+"georgia","Silence, city-owned Laurel Grove Cemetery (1875).[94]",1875
+"georgia","Confederate Monument, Forsyth Park (1879) (To be officially renamed ""Civil War Monument"" in 2018)[91][93]",1879
+"georgia","Confederate Monument, city street median (1879).[56]",1879
+"georgia","Macon: Bibb County Confederate Monument, triangle park downtown (1879).[81] Moved to present location in 1956.Confederate Monument in Macon, GA, c. 1870s",1879
+"georgia","Sparta: Hancock County Confederate Monument (1881)",1881
+"georgia","Crawfordville: Alexander H. Stephens statue (1893), A. H. Stephens Historic Park, Crawfordville[59]",1893
+"georgia","Crawfordville: Confederate Monument (1898)",1898
+"georgia","Elbert County Confederate Memorial (1898), Elberton Town Plaza[70]",1898
+"georgia","Greensboro: Greene County Confederate Monument (1898)",1898
+"georgia","Americus: Confederate Monument (1900)",1900
+"georgia","""General"" (1901), monument erected at the location where Confederate locomotive The General—stolen by Union Army soldiers in 1862—was finally stopped following the Great Locomotive Chase[90]",1901
+"georgia","Athens: Allen D. Candler Hall at the University of Georgia (1901)[14]",1901
+"georgia","Colonel Francis S. Bartow Bust, Forsyth Park (1902).[91][92]",1902
+"georgia","General Lafayette McLaws Bust, Forsyth Park (1902).[92]",1902
+"georgia","LaGrange: Monument to the Confederate Soldier, median (1902).[79]",1902
+"georgia","Warrenton: Warren County Confederate Monument, county courthouse (1904)[32]",1904
+"georgia","Cedartown: Polk County Confederate Monument (1906)",1906
+"georgia","Covington: Confederate War Memorial (1906)",1906
+"georgia","Statesboro: Confederate Memorial, Bulloch County Courthouse (1906)[25]",1906
+"georgia","Forsyth: Confederate Monument (1907)",1907
+"georgia","Monroe: Confederate Monument (1907)",1907
+"georgia","Statue of John Brown Gordon, Georgia State Capitol grounds (1907). ""One of the leading proponents of both the New South creed and the Lost Cause, a philosophy that greatly romanticized the South's role in the war. Moreover, he is generally acknowledged as having been the head of the Ku Klux Klan in Georgia.",1907
+"georgia","At Arms Rest Monument, Upson County Courthouse (1908)[26]",1908
+"georgia","Eatonton: Eatonton Confederate Monument, median in front of the Putnam County Courthouse (1908).[67]",1908
+"georgia","Hartwell: Confederate Monument (1908)",1908
+"georgia","Hawkinsville: Confederate Monument (1908)",1908
+"georgia","Lumpkin: Stewart County Confederate Monument (1908), included in Lumpkin Commercial Historic District[20]",1908
+"georgia","Marietta: Confederate memorial (1908), Marietta Confederate Cemetery[83]",1908
+"georgia","Perry: Houston County Confederate Monument (1908)",1908
+"georgia","Vienna: Dooly County Confederate Monument, county courthouse (1908)[31]",1908
+"georgia","""Old Joe"", Hall County Confederate Monument, town square (1909).[72]",1909
+"georgia","Abbeville: Confederate Memorial Monument (1909)",1909
+"georgia","Griffin: Confederate Monument, Veterans Memorial Plaza (1909).[73]",1909
+"georgia","LaFayette: Walker County Confederate Monument, John B. Gordon Hall (1909).[77][78]",1909
+"georgia","Madison: Morgan County Confederate Monument, Hill Park (1909).[82]",1909
+"georgia","Millen: Jenkins County Confederate Monument, Jenkins County Courthouse (1909)",1909
+"georgia","Moultrie: Colquitt County Confederate Monument, Colquitt County Courthouse (1909)",1909
+"georgia","Nathan Bedford Forrest Monument (1909), UDC Monument[104]",1909
+"georgia","Carnesville: Franklin County Confederate Monument (1910)",1910
+"georgia","Carrollton: Confederate Monument (1910)",1910
+"georgia","Cochran: Bleckley County Confederate Monument, old Cochran City School (1910).[54][55]",1910
+"georgia","Cuthbert: Randolph County Confederate Monument, city park (1910).[60]",1910
+"georgia","Eastman: Confederate Monument of Eastman (1910)",1910
+"georgia","Ellaville: Schley County Confederate Monument (1910)",1910
+"georgia","McDonough: Confederate Memorial, courthouse square (1910)[84]",1910
+"georgia","Monticello: Jasper County Confederate Monument, City Square (1910).[87] ""To the Confederate soldiers of Jasper County, the record of whose sublime self sacrifice and undying devotion to duty, in the service of their country is the proud heritage of a local posterity.""[88]",1910
+"georgia","Tifton: Tift County Confederate Memorial, Fulwood Park (1910), rededicated 1992.[97]",1910
+"georgia","Waycross: Ware County Confederate, Phoenix Park (1910).[100]",1910
+"georgia","Bibb County Courthouse and Confederate Monument in Macon, GA c.1870sMontezuma: Macon County Confederate Monument (1911).[86] ""The first Macon County monument is currently located in Fannie Carmichael Park and faces east. It is a soldier with both hands on his grounded rifle. There are lion heads on each side. It was erected by the Phil Cook Chapter of the UDC in January 1911. The monument was moved in 1965 from the middle of Dooly Street in the middle of Montezuma.""[19]",1911
+"georgia","Butler: Taylor County Confederate Monument (1911)",1911
+"georgia","Cordele: Crisp County Confederate Monument, community clubhouse (1911).[58]",1911
+"georgia","Jackson: Monument to Butts County Confederate Soldiers (1911)",1911
+"georgia","Jeffersonville: Confederate Memorial, across the street from the Twiggs County Courthouse (1911).[75]",1911
+"georgia","Macon: ""Women of the South"" (1911), UDC monument featuring a young soldier receiving aid from a mother and young girl, as well as a bas-relief showing both a pre-war family, and one devastated by war. Moved from city hall to a nearby park in 1934.[21]",1911
+"georgia","Ocilla: Irwin County Confederate Monument (1911)",1911
+"georgia","Peace Monument (1911), Allen George Newman, sculptor, inside the 14th Street gate of Piedmont Park. Features a winged goddess declaring ""Cease Firing – Peace Is Proclaimed,"" to a Confederate soldier holding a rifle. Defaced by protestors after the Charlottesville Unite the Right rally, on August 13, 2017.[42] A committee set up by then-Mayor Kasim Reed in 2017 recommended it be removed.[43] Since state law prohibits removal, a ""contextual"" panel was added in 2019, stating that the monument ""excludes all African Americans, of which nearly 200,000 served in the U.S. Army"".[12][44]",1911
+"georgia","Thomson: Monument to the Women of the Sixties, McDuffie County Chamber of Commerce (1911).[96]",1911
+"georgia","Valdosta: Confederate memorial, Lowdnes County Courthouse (1911)[30]",1911
+"georgia","Dublin: Laurens County Confederate Monument (1912)",1912
+"georgia","Johnson statue (1912) in downtown Dalton. The UDC commissioned Belle Kinney to sculpt the bronze statue, in which Johnston is posed with ""an expression of deep thought, with his sword resting at his feet"". Kinney explained, ""General Johnston, in command of an army vastly inferior in numbers to General Sherman's army, had to use his brains more than his sword; hence I made the sword subservient to the brain.""[61]",1912
+"georgia","Milledgeville: Confederate Memorial Fountain, downtown median, erected by United Daughters of the Confederacy (1912). 20 feet (6.1 m) fall. Originally across from Post Office and Courthouse; later moved to street in front of Georgia Military College. ""On the front is 'CSA' and the furled battle flag with a broken shaft. Under the lion's head is a covered bowl. The soldier is standing with a gun. His heroism in the presence of the conquering foe was equaled only by his generosity to his fallen enemy. Reading around the monument, starting in the back it reads: '1861'; To the memory of the Confederate soldier who's [sic] game is as imperishable as the everlasting hills, who's [sic] courage is as unrivaled. Sing the dawn of civilization who's [sic] name shines in undying glory to the pages of history this monument is lovingly erected by the Robert E. Lee Chapter Daughters of the Confederacy of Milledgeville, Georgia. Unconquerable patriotism and – self-sacrifice rendered, adopted the effort of his enemies. After his flag had folded forever, to destroy his proud inheritance.""[85]",1912
+"georgia","Conyers: Confederate Monument (1913)",1913
+"georgia","Douglasville: Confederate War Memorial (1914)",1914
+"georgia","Sidney Lanier Monument (1914), a stele and bust honoring Sidney Lanier, a former Confederate soldier and the ""Poet of the Confederacy"".[45][46]",1914
+"georgia","McDonough: Confederate Memorial Drinking Fountain (1915)",1915
+"georgia","Lexington: Oglethorpe County Confederate Monument (1916)",1916
+"georgia","Cobb County: Kennesaw Mountain National Battlefield Park, tribute to 14 generals from Georgia (1917)",1917
+"georgia","First Cannon Ball Monument, Upson County Courthouse (1919)[27]",1919
+"georgia","Irwin County: Jefferson Davis Memorial Historic Site (1920)",1920
+"georgia","Toccoa: Stephens County Confederate Monument, county courthouse (1922)[29]",1922
+"georgia","Canton: Confederate Memorial Arch, Brown Park (1923).[53]",1923
+"georgia","Oglethorpe: Confederate Monument, Courthouse lawn (1923)[24]: 70  ""Erected by the Oglethorpe Chapter of the UDC in 1924. It consists of a block of Ga marble flanked by marble globes surmounted by a third globe (surrounded by a fence), sits near the courthouse, date on monument is February 20, 1993, but newspaper establishes date of dedication as April 26, 1924. Originally, it was built with a fountain near an old artesian well in the intersection of highway 49 and Sumpter Street and moved to the present site around 1935.""[19]",1923
+"georgia","Springfield: Confederate Memorial, across from Effington County Courthouse (1923).[95]",1923
+"georgia","Calhoun: Confederate Soldier and Memorial Arch (1927).[52]",1927
+"georgia","Watkinsville: Confederate monument (1927); first erected in Watkinsville City Park[34]",1927
+"georgia","Hinesville: Liberty County Confederate Monument, Liberty County Courthouse (1928)",1928
+"georgia","Athens: Joseph E. Brown Hall at the University of Georgia (1932)[14]",1932
+"georgia","Peachtree Battle Avenue Monument (1935), a stone-engraved memorial commemorating the Battle of Peachtree Creek (1864). Because state law prohibits its removal, a panel was added in 2019 saying: ""[The monument] describes the United States after the civil war as a perfected nation. This ignores the segregation and disenfranchisement of African Americans and others that still existed in 1935.""[12]",1935
+"georgia","Confederate Wayside Home Monument, wide median (1936).[99]",1936
+"georgia","Eatonton: Birthplace of Lucius Quintus Cincinnatus Lamar (1936)",1936
+"georgia","Tyler Home – Ladies Aid Society Memorial, Veteran's Parkway (1936).[57][dubious – discuss]",1936
+"georgia","Washington: The Dissolution of the Confederate Government/Last Meeting Stone, Wilkes County Courthouse (1938)[33]",1938
+"georgia","Eternal Flame of the Confederacy Monument (1939), a pre-Civil War gas streetlamp that was part of the Atlanta premiere of the film Gone with the Wind, now at the Atlanta History Center. Its plaque reads:",1939
+"georgia","Commerce: UDC monument (1941) in Spencer Park to women and veterans of the War Between the States. High school students sang Dixie at the dedication ceremony.[34]",1941
+"georgia","Marker for Confederate Hospitals, on Courthouse Square (1955). Text: ""In Newnan between 1862 and 1865 were seven Confederate hospitals — Bragg, Buckner, ""College Temple"", ""Coweta House,"" Foard, Gamble and Pinson's Springs. More than 10,000 Confederate sick and wounded and about 200 Federal soldiers wounded in the Battle of Brown's Mill were cared for in these hospitals and in private homes. The hospitals were directed and supervised by Samuel H. Stout, Army Medical Director Department of Tennessee. Loyal men and women of the county rendered valuable aid.""[23]",1955
+"georgia","Newnan: Stone monument to William Thomas Overby, called ""Nathan Hale"" of the Confederacy (1956). Erected 1956 by Alfred Colquitt and Newnan Chapters UDC. ""[89]",1956
+"georgia","Catoosa County: monument (1977) to Confederate Gen. Bushrod Johnson, located within Chickamauga and Chattanooga National Military Park.[105]",1977
+"georgia","Thomson: McDuffie and Columbia Counties Confederate Monument, McDuffie County Courthouse (1986)[28]",1986
+"georgia","Lawrenceville: Lawrenceville Confederate Memorial (1990)",1990
+"georgia","Mount Vernon: Confederate Monument, Montgomery County Courthouse (1997)",1997
+"georgia","Franklin: Heard County Confederate Monument, Veterans Park (1999).[71]",1999
+"georgia","Flag of Georgia since 2003The current (2024) Georgia flag is based on the first national flag of the Confederacy, which was nicknamed the ""Stars and Bars"".[7]",2024
+"mississippi","Lee County (1866)",1866
+"mississippi","Benton County (1870) named for CSA Brig. Gen. Samuel Benton who was also a politician that attended the Mississippi secessionist convention.",1870
+"mississippi","Liberty: Confederate Monument (1871), the first Confederate monument in Mississippi.[26]",1871
+"mississippi","Monument to Confederate Dead (1873), Friendship Cemetery[22]",1873
+"mississippi","Natchez: Confederate Monument (1890)",1890
+"mississippi","Cedar Hill Cemetery: Soldiers' Rest Confederate Monument (1893), where an estimated 5,000 Confederate soldiers are buried.[32]",1893
+"mississippi","Canton: Howcott Monument to Loyal Servants of the Harvey Scouts (1894)",1894
+"mississippi","Confederate Monument (1894), Friendship Cemetery[21]",1894
+"mississippi","Aberdeen: Confederate Monument in Old Aberdeen Cemetery (1900)",1900
+"mississippi","Port Gibson: Confederate Monument (1900)[14]",1900
+"mississippi","Macon: Confederate Memorial Monument (1901)",1901
+"mississippi","Fayette: Confederate Soldier Sculpture (1904)",1904
+"mississippi","Beulah: Confederate Monument (1905), Beulah Cemetery[16]",1905
+"mississippi","Carrollton: Confederate Monument and flag, Carroll County Courthouse (1905)[8][9]",1905
+"mississippi","Okolona: Our Confederate Dead (1905)",1905
+"mississippi","Confederate Cemetery Memorial (1906)[44]",1906
+"mississippi","Jefferson Davis County (1906)",1906
+"mississippi","Port Gibson: Claiborne County's Tribute to Her Sons Who Served in the War of 1861–65. (1906)",1906
+"mississippi","Brandon: Rankin County Confederate Monument (1907)[7]",1907
+"mississippi","Confederate Monument (1907)[36]",1907
+"mississippi","Oxford: ""Oxford is one of the few small Southern towns with two Confederate monuments. It was a compromise between two factions of the United Daughters of the Confederacy, one group wanting the statue placed on Courthouse Square, the other arguing that it should be on the campus of the University of Mississippi.""[12]Confederate Monument (1907). Artist: John A. Stinson. Figure of Confederate soldier at parade rest, facing south. Furled Confederate flag.[13]",1907
+"mississippi","Cleveland: Confederate Monument (1908) by the Bolivar Troop Chapter of UDC, Bolivar County",1908
+"mississippi","Duck Hill: Confederate Soldiers Monument (1908)",1908
+"mississippi","Forrest County (1908)",1908
+"mississippi","Lexington: Confederate Monument (1908)",1908
+"mississippi","Raymond: Confederate Monument (1908)",1908
+"mississippi","Greenville: Confederate Monument (1909), erected by United Daughters of the Confederacy. One face: ""For those who encountered the perils of war in the defense of the sacred cause of states rights and constitutional government. // Jefferson Davis."" Another side: ""The sublimest word in the English language is duty. // Robert E. Lee // No brave battle for truth and right was ever fought in vain. // Randolph H. M'Kim."" Another side: ""It is due the truth of history that the fundamental principles for which our fathers contended should be often reiterated in order that the purpose which inspired them may be correctly estimated and the purity of their motives be abundantly vindicated. // Charles B. Galloway""",1909
+"mississippi","Vicksburg National Military Park: Lt. Gen. Stephen D. Lee statue (1909).[34]",1909
+"mississippi","Winona: Confederate Memorial Statue (1909)",1909
+"mississippi","Grenada: Confederate Monument (1910) in Public Square[24]",1910
+"mississippi","Hattiesburg: Confederate Memorial (1910) by UDC",1910
+"mississippi","Hattiesburg: Forrest County Confederate Memorial (1910)",1910
+"mississippi","Brooksville: Our Heroes Monument (1911)",1911
+"mississippi","Gulfport: Confederate Monument (1911)",1911
+"mississippi","Heidelberg: Confederate Statue (1911)",1911
+"mississippi","Kosciusko: Attala County Courthouse and Confederate Monument (1911)",1911
+"mississippi","Quitman: Clarke County Courthouse and Confederate Monument (1911)",1911
+"mississippi","Columbus: Lowndes County Confederate Monument (1912)",1912
+"mississippi","Laurel: Confederate Memorial (1912)",1912
+"mississippi","Meridian: Confederate Monument (1912)",1912
+"mississippi","Philadelphia: Confederate Monument (1912)",1912
+"mississippi","Vaiden: Vaiden Confederate Monument (1912)",1912
+"mississippi","Greenwood: Confederate Monument (1913)",1913
+"mississippi","Sumner: Confederate Monument (1913)",1913
+"mississippi","Greenwood: Confederate Memorial Building (1915)[23]",1915
+"mississippi","Forrest County Agricultural High School (1916)",1916
+"mississippi","Hazlehurst: Confederate Monument (1917)",1917
+"mississippi","Women of the Confederacy Monument (1917), on south side of Capitol grounds. Cost was $20,000, sculpted by Belle Marshall Kinney. ""The monument features two female figures and one male figure, a wounded and dying soldier. To the left of the soldier, a sympathetic woman is presenting a palm of glory to the soldier, a symbol of triumph even in death. Above both the soldier and the woman stands 'Fame'. She, in turn, is placing a wreath on the head of the woman in recognition of her contribution to the Confederate cause. Below the bronze figures are four inscriptions facing each direction, and dedicated to 'our' mothers, daughters, sisters and wives. On the southern face, which is the front of the monument, is a quote from Jefferson Davis which, among other virtues, praises the women 'whose pious ministrations to our wounded soldiers soothed the last hours of those who died far from the objects of their tenderest love.'""[5]",1917
+"mississippi","Louisville: Confederate Monument (1921)",1921
+"mississippi","Jackson: The School Board has announced the following elementary schools will be renamed before the 2018–2019 school year:[42]Lee Elementary School (1922)[1] -now Shirley Elementary School.",1922
+"mississippi","Amory: Amory's Tribute to the Heroes of 1861–1865 (1924)",1924
+"mississippi","Clinton: Confederate Monument (1928), Clinton Cemetery[20]",1928
+"mississippi","Jeff Davis Elementary School (1959)",1959
+"mississippi","South Forrest Attendance Center (1960)",1960
+"mississippi","Vicksburg National Military Park: Texas Monument (1961), listing all Texas units on the Vicksburg defensive line, in Walker's Texas Division, and in Joseph E. Johnston's Army.[35]",1961
+"mississippi","Lamar Hall (1977) memorializes Lucius Q. C. Lamar, a slaveholder who drafted the Mississippi's order of secession and funded his own CSA regiment. Post-war, he agitated for white supremacy, such as a speech before the 1875 election which he said ""involved the supremacy of the unconquered and unconquerable Saxon race,""[40]",1977
+"mississippi","Oxford: Lamar Hall (1977) at University of Mississippi see schools below",1977
+"mississippi","Corinth: Corinth Confederate Memorial (1992)",1992
+"mississippi","The Battle of Ellis Bridge Monument (1994)[37]",1994
+"mississippi","President Jefferson Davis and Sons (2008), a life-size bronze statue by sculptor Gary Casteel and commissioned by the Sons of Confederate Veterans (SCV) to commemorate the 150th anniversary of the birth of Jefferson Davis.[17][18][19]  The statue features Davis standing with his arms around both his son Joe, and Jim Limber, a mixed-race stepchild of the Davis family who the SVC called ""a person lost in history by revisionist historians, who felt his existence would impair their contrived notions of Davis"".[18]  The SCV first offered the statue to the American Civil War Center at the Tredegar Iron Works in Richmond, Virginia in order to balance the importance of a statue already located there depicting Lincoln with his son while they visited the burned-out Confederate capital in 1865.[18][19]  When the center would not ""guarantee where or whether the statue would be displayed or explain how it might be interpreted"", the SCV rescinded its offer.[18]  The statue was eventually placed at the SVC-managed Jefferson Davis Presidential Library and Museum at Beauvoir in 2010.[17]",2008
+"north_carolina","Confederate Soldiers Monument (1868) at Cross Creek Cemetery; the first Confederate monument in North Carolina[14]",1868
+"north_carolina","Joseph E. Johnston, BentonvilleConfederate Soldiers Monument (1868) in FayettevilleFort Fisher Confederate Monument, Kure BeachLenoir, North CarolinaLexington, North Carolina (ca. 1920)New Bern, North CarolinaHenry Lawson Wyatt in Raleigh, North CarolinaConfederate graves and monument, Historic Oakwood Cemetery, RaleighGloria Victis, Salisbury",1868
+"north_carolina","Pelham (1868), named for CSA Col. John Pelham from Alabama",1868
+"north_carolina","Confederate Monument (1870), Historic Oakwood Cemetery[54]",1870
+"north_carolina","Harnett County: Confederate Monument (1872) at Chicora Civil War Cemetery to soldiers killed at the Battle of Averasborough, ""In Memory of our Confederate Dead Who Fell Upon That Day""[54]",1872
+"north_carolina","Oakdale Cemetery Confederate Mound (1872); North Carolina's first soldier statue[54]",1872
+"north_carolina","Pender County (1875), named for CSA Gen. William Dorsey Pender",1875
+"north_carolina","Vanceboro (1876), named for Zebulon Vance",1876
+"north_carolina","Vance County (1881), named for CSA soldier and North Carolina governor Zebulon Baird Vance",1881
+"north_carolina","Carrboro (1882), named for CSA soldier and white supremacist Julian Carr",1882
+"north_carolina","New Bern: Confederate Monument (1885), Cedar Grove Cemetery[62]",1885
+"north_carolina","Confederate Soldiers Monument at Green Hill Cemetery (1888)[14] (Removed July 4, 2020)[51]",1888
+"north_carolina","Washington, Virginia: Confederate Soldiers Monument (1888), Oakdale Cemetery[14]",1888
+"north_carolina","Ramseur, (1889), formerly called Columbia and renamed for CSA general Stephen Dodson Ramseur[76]",1889
+"north_carolina","Concord: Confederate Soldiers Monument (1892) at Old Cabarrus County Courthouse[14]",1892
+"north_carolina","Confederate Soldiers Monument (1892)[14]",1892
+"north_carolina","Confederate Monument (1895)[33]",1895
+"north_carolina","North Carolina State Capitol. The Capitol currently houses the offices of the Governor of North Carolina. The legislature relocated to its current location in the North Carolina State Legislative Building in 1963.In 2017, Governor Roy Cooper unsuccessfully petitioned the North Carolina Historical Commission to move the following three Confederate monuments from the grounds of the state Capitol to the Bentonville Battlefield, a Civil War site in Johnston County.[3][4] The Commission found that the 2015 law prohibited their removal, but recommended signage to add context to the monuments, including noting that slavery was a cause of the Civil War. The Commission also found unanimously that the Capitol monuments are ""an overrepresentation and over-memorialization"" of the Confederacy and Civil War in North Carolina. The Commission urged the state’s Department of Natural and Cultural Resources to plan and raise money for a monument recognizing the contributions of African Americans to North Carolina's history.[5] On June 19, 2020, the two statues at the base of the monument were toppled by protestors. The protestors proceeded to drag one statue to the streets and hang it from a street light.[6]Monument Removed June 21, 2020 [7] - North Carolina State Confederate Monument (1895), also known as the Soldiers and Sailors Monument. ""This 75-foot-tall monument to fallen Confederate soldiers is located on the State Capitol grounds. At the top of the column is a statue depicting a Confederate artillery soldier holding a gun. Near the bottom of the column are two statues, one representing the Confederate infantry and the other a Confederate cavalryman. Two 32 pounder naval cannons stand on each side of the monument.""[8] Contains the Seal of North Carolina. Front: ""To Our Confederate Dead."" Rear: ""First at Bethel, last at Appomattox"".",1895
+"north_carolina","High Point: Confederate Monument (1899), Oakwood Cemetery[56]",1899
+"north_carolina","Columbia: Confederate Soldiers Monument (1902); ""In appreciation of our faithful slaves""[24][25]",1902
+"north_carolina","Confederate Soldiers Monument (1902)[14]",1902
+"north_carolina","Wilson: Confederate Monument at Maplewood Cemetery (1902)[71]",1902
+"north_carolina","Asheville: Confederate Soldiers Monument (1903), Newton Academy Cemetery[14]",1903
+"north_carolina","Confederate Soldiers Monument (1904)[14]",1904
+"north_carolina","Hendersonville: Confederate Soldiers Monument (1905)[14]",1905
+"north_carolina","Lexington: Confederate Soldiers Monument (1905)[14] Removed from Lexington public square in 2020.[58]",1905
+"north_carolina","Monument to 60th Regiment North Carolina Volunteers (1905)",1905
+"north_carolina","Confederate Soldiers Monument (1906)[14]",1906
+"north_carolina","Statesville: Confederate Soldiers Monument (1906) at Iredell County Courthouse[14]",1906
+"north_carolina","Lee County (1907), named for CSA Gen. Robert E. Lee",1907
+"north_carolina","Lumberton: Confederate Soldiers Monument (1907)",1907
+"north_carolina","Newton: Catawba County Confederate Soldiers Monument (1907), Old Catawba County Courthouse[14][30]",1907
+"north_carolina","Shelby: Confederate Soldiers Monument (1907) at Old Courthouse[14]",1907
+"north_carolina","Zebulon (1907), named for Zebulon Vance",1907
+"north_carolina","Edenton: Confederate Soldiers Monument (1909); moved from courthouse in 1961[14][39]",1909
+"north_carolina","Franklin: Confederate Soldiers Memorial (1909)",1909
+"north_carolina","Oxford: Granville Gray (1909), a memorial to the Confederate Veterans of Granville County",1909
+"north_carolina","Cornelius: Confederate Soldiers Monument (1910), Mt. Zion United Methodist Church. 19600 Zion Avenue.[38]",1910
+"north_carolina","Henry Lawson Wyatt Memorial Fountain (1910)[14]",1910
+"north_carolina","Lenoir: Confederate Soldiers Monument (1910) in town square[14]",1910
+"north_carolina","Monroe: Located at the Old Union County Courthouse; the obelisk (1910) was erected by the UDC Monroe chapter[61]",1910
+"north_carolina","Rutherfordton: Confederate Soldiers Monument (1910)",1910
+"north_carolina","Asheboro: Confederate Soldiers Monument (1911)",1911
+"north_carolina","Elizabeth City: Confederate Soldiers Monument (1911)",1911
+"north_carolina","Hoke County (1911), named for CSA Maj. Gen. Robert Hoke",1911
+"north_carolina","Lincolnton: Confederate Soldiers Memorial Drinking Fountain (1911)",1911
+"north_carolina","Hertford: Confederate Soldiers Monument (1912)",1912
+"north_carolina","Justice: Confederate Soldiers Monument (1912) at Stallings Memorial Park[14]",1912
+"north_carolina","Laurinburg: Confederate Soldiers Monument (1912), sponsored by UDC. ""The Scotland County monument has been moved several times in the years since first being placed. Originally it sat in the middle of the road in front of the courthouse at Main and Church streets. It was then moved onto the grounds of the courthouse after becoming a traffic hazard. When the new courthouse was completed in the 1960s, the monument moved with it and was placed in its current location.... [T]he inside contains time capsules.""[28]",1912
+"north_carolina","Monument Removed June 21, 2020 [7] - Henry Lawson Wyatt Monument (1912). He was the first Confederate soldier to die in battle. Sculpture by Gutzon Borglum. Inscriptions:Front: HENRY LAWSON WYATT / PRIVATE CO. A / BETHEL REGIMENT / NORTH CAROLINA VOLUNTEERS / KILLED AT BETHEL CHURCH / JUNE 10, 1861 / FIRST CONFEDERATE SOLDER | TO FALL IN BATTLE IN THE | WAR BETWEEN THE STATES.Rear: WYATT'S COMRADES / IN DASH TO BURN THE HOUSE / GEORGE T. WILLIAMS / JOHN H. THORPE / ROBERT H. RICKS / ROBERT H. BRADLEY / THOMAS FALLON / ERECTED BY THE NORTH CAROLINA | DIVISION, UNITED DAUGHTERS | OF THE CONFEDERACY. / JUNE 10, 1912Base, east face: GORHAM. Co. FOUNDERS.[12]",1912
+"north_carolina","Warrenton: Confederate Soldiers Monument (1913)",1913
+"north_carolina","Winton: Confederate Soldiers Monument (1913)[14]",1913
+"north_carolina","Burgaw: Confederate Soldiers Monument (1914)",1914
+"north_carolina","Confederate Soldiers Monument (1914) to ""Our Confederate Dead"".[59] The monument was formerly on the street in front of Louisburg College, but the College has grown to surround the monument. Some on campus want it removed. ""It's not clear whether the town owns the statue, or whether it belongs to the county or to the quiet but still active Joseph J. Davis 537 chapter of the United Daughters of the Confederacy.""[60]",1914
+"north_carolina","Graham: Confederate Soldiers Monument (1914), Alamance County Courthouse.[14] Demonstrators called for its removal in 2017, and the matter was discussed at an Alamance County Commission meeting.[27]",1914
+"north_carolina","Greenville: Confederate Soldiers Monument (1914)",1914
+"north_carolina","Monument Removed June 21, 2020 [9] - Monument to North Carolina Women of the Confederacy, also called Confederate Women's Monument (1914). ""The seven foot tall monument, made possible through a private donation, honors the hardships and sacrifices of North Carolina women during the Civil War. A bronze sculpture depicts an older woman, a grandmotherly figure, holding a book as she sits next to a young boy holding a sword. It sits on top of a granite base with bronze bas-relief plaques. The woman, representing the women in the South as the custodians of history, imparts the history of the Civil War to the boy. The two relief plaques portray the Civil War; the eastern side shows soldiers departing for war and leaving their loved ones behind, while the western side depicts a weary or injured Confederate soldier returning home.""[10] In 2019, a protester placed Ku Klux Klan hoods on the two figures.[11]",1914
+"north_carolina","Gatesville: Confederate Soldiers Monument (1915)[14]",1915
+"north_carolina","Last Meetings of the Confederate Cabinet Marker (1915)",1915
+"north_carolina","Sylva: Confederate Soldiers Monument (1915)",1915
+"north_carolina","Clinton: Monument removed July 12, 2020.[22] Confederate Soldiers Monument (1916). ""In honor of the Confederate soldiers of Sampson County who bore the flag of a nation's trust and fell in a cause though lost still just and died for me and you.""[23]",1916
+"north_carolina","Rocky Mount: Nash County Confederate Monument (1917), honoring Confederate war dead in Edgecombe County and Nash Counties; rededicated to all veterans of all wars in 1976. On June 2, 2020, the City Council of Rocky Mount voted to remove it.[64]",1917
+"north_carolina","Currituck: Confederate Soldiers Monument ""To Our Confederate Dead 1861–1865"" (1918)[26]",1918
+"north_carolina","Morganton: Confederate Soldiers Monument at Old Courthouse (1918)[14]",1918
+"north_carolina","Morgantown: Confederate Soldiers Monument (1918)",1918
+"north_carolina","CSA Gen. Robert Hoke Monument (1920)",1920
+"north_carolina","Confederate Memorial (1921)[citation needed]",1921
+"north_carolina","Yanceyville: Confederate Soldiers Monument (1921), Old Caswell County Courthouse[14]",1921
+"north_carolina","Holly Springs: Confederate Soldiers Monument (1923)",1923
+"north_carolina","Louisburg: The Confederate Memorial Drinking Fountain (1923) is dedicated to North Carolinian Orren Randolph Smith, who designed the Stars and Bars, the first official flag of the Confederacy. It is five feet high, six feet across, and has separate ""white"" and ""colored"" drinking fountains.[14][29] A similar marker is in Wilson, North Carolina (below).",1923
+"north_carolina","Confederate Soldiers Monument (1924)",1924
+"north_carolina","Albemarle: Confederate Soldiers Monument (1925)[14]",1925
+"north_carolina","Beaufort: Carteret County Confederate Soldiers Monument (1926) at the Carteret County Courthouse. ""TO THE MEMORY OF THE CONFEDERATE DEAD OF CARTERET COUNTY 1861-1865 ERECTED BY THE DAUGHTERS OF CONFEDERACY FORT MACON CHAPTER BEAUFORT, N.C. 1926 NOT EVEN TIME CAN DESTROY HEROISM"" [21]",1926
+"north_carolina","Beaufort: Confederate Soldiers Monument (1926), Carteret County Courthouse[14]",1926
+"north_carolina","Robert E. Lee Dixie Highway marker (1926), ""In Loving Memory of Robert E. Lee...'The Shaft Memorial and Highway Straight Attest His Worth – He Cometh to His Own'""[46]",1926
+"north_carolina","Wilson: Memorial Drinking Fountain (1926). This fountain, like a similar one from the same artist in Louisburg, NC, originally had ""white"" and ""colored"" water fountains, separated by the Confederate flag. The water bowls have been removed and replaced with generic tops, and the labels ""white"" and ""colored"" sandblasted off; their location is clearly visible.[32]",1926
+"north_carolina","Calvary Episcopal Church Memorial (1927), ""During the Civil War this Church was Used as Barracks by Confederate Troops""[49]",1927
+"north_carolina","Tuxedo: Robert E. Lee Dixie Highway Marker (1927)[69]",1927
+"north_carolina","Albert Pike marker (1928), ""Arkansas Poet of the Confederacy""[48]",1928
+"north_carolina","Confederate Arsenal (1928)",1928
+"north_carolina","Enfield: Confederate Soldiers Memorial (1928) at Elmwood Cemetery. Originally located in downtown Enfield, the sculpture contains a drinking fountain.[14]",1928
+"north_carolina","Plymouth: Battle of Plymouth monument (1928) at Washington County Courthouse[31]",1928
+"north_carolina","Zebulon Baird Vance marker (1928)[47]",1928
+"north_carolina","1929 Confederate Reunion Marker (1929). ""Erected by citizens of City of Charlotte and County of Mecklenburg commemorating the 39th Confederate Reunion June 4–7, 1929."" Currently (2018) protected by a glass enclosure.[35]",1929
+"north_carolina","Halifax: General Junius Daniel marker (1929)[53]",1929
+"north_carolina","Snow Hill: Confederate Soldiers Monument (1929)[14]",1929
+"north_carolina","Henry Timrod marker (1930), recognizing Timrod as ""Laureate of the Confederacy""[43]",1930
+"north_carolina","Memorial plaque to Lieutenant William Henry Hardy (1930), ""the First Soldier from Buncombe County to Fall in the War Between The States""[19]",1930
+"north_carolina","Orren Randolph Smith marker (1930)[42]",1930
+"north_carolina","Rockingham: Confederate Soldiers Monument (1930)",1930
+"north_carolina","Confederate Monument (1931)",1931
+"north_carolina","Jefferson Davis marker (1931), recognizing Davis as ""A Statesman with Clean Hands and Pure Heart""[41]",1931
+"north_carolina","Confederate Monument (1932)",1932
+"north_carolina","Faison: Monument to the ""Confederate Grays"" 20th Regiment North Carolina State Troops (1932)[14]",1932
+"north_carolina","Forest City: Forest City Confederate Monument (1932)",1932
+"north_carolina","Fort Fisher Confederate Monument (1932); UDC monument erected at former site of Fort Fisher headquarters building[57]",1932
+"north_carolina","Matthew Fontaine Maury marker (1932). A Confederate Navy commander and slave owner, Maury investigated resettling American slaves in Brazil.[44][45]",1932
+"north_carolina","Confederate Women Monument (1934)[14]",1934
+"north_carolina","Monument to Civil War Captain and North Carolina legislator Samuel A'Court Ashe (1940), two plaques on a large granite block.[13]",1940
+"north_carolina","Waynesville: Confederate Soldiers Monument (1940)",1940
+"north_carolina","Jefferson Davis Camp marker, showing where Davis ""hitched his horse to a tree which stood on this spot"" (1941)[37]",1941
+"north_carolina","Judah P. Benjamin marker (1944)[40]",1944
+"north_carolina","Judah P. Benjamin Memorial ""erected in His Honor by Temple Israel and Temple Beth El, the Jewish Congregations of Charlotte, as a Gift to the North Carolina Division, United Daughters of the Confederacy"" (1948)[36]",1948
+"north_carolina","North Carolina Confederate Veterans Forest (1956)[77] 125,000 spruce pine trees were planted by the UDC in the 1940s as a living memorial to North Carolina Confederate Veterans. The forest was rededicated in 2001. The area is located beneath Mt. Hardy near the Blue Ridge Parkway.",1956
+"north_carolina","Jacksonville: Confederate Soldiers Monument (1957)",1957
+"north_carolina","Taylorsville: Confederate Soldiers Monument (1958)[14]",1958
+"north_carolina","Jefferson Davis Plaque (1960)",1960
+"north_carolina","Trenton: Confederate Soldiers Monument (1960)",1960
+"north_carolina","Confederate Soldiers Monument (1977)",1977
+"north_carolina","Confederate Soldiers Monument (1985)[52]",1985
+"north_carolina","Army of Tennessee Monument (1986)[14]",1986
+"north_carolina","Mocksville: Davie County War Memorial (1987)",1987
+"north_carolina","Danbury: Confederate Soldiers Monument (1990)",1990
+"north_carolina","Selma: The Last Grand Review Monument (1990)[67]",1990
+"north_carolina","Confederate Monument (1998)",1998
+"north_carolina","Wentworth: Rockingham County Confederate Monument (1998)[70]",1998
+"north_carolina","Wilkesboro: Confederate Soldiers Monument (1998)",1998
+"north_carolina","Dobson: Confederate Soldiers Monument (2000)",2000
+"north_carolina","Middletown: Confederate Soldiers war Monument (2001)",2001
+"north_carolina","Dallas: Gaston County Confederate Soldier Monument (2003)",2003
+"north_carolina","Burnsville: Confederate Soldiers Monument (2009)",2009
+"north_carolina","Joseph E. Johnston Monument stands on private property near the State Operated historic site (2010)[34]",2010
+"north_carolina","Thomasville: Thomasville and Davidson County Civil War Memorial (2010)[68]",2010
+"north_carolina","Bakersville: Mitchell County's Confederate Dead Monument (2011) commemorates 79 men ""who died for their freedom and independence. And not for slavery.""[20]",2011
+"north_carolina","1929 Confederate Reunion Marker (1929). ""Erected by citizens of City of Charlotte and County of Mecklenburg commemorating the 39th Confederate Reunion June 4–7, 1929."" Currently (2018) protected by a glass enclosure.[35]",2018
+"other","Levy County (1845), named for David Levy Yulee, a Florida businessman, senator, and strong supporter of slavery, who withdrew from the U.S. Senate in 1861 and served nine months in prison after the Civil War for supporting the Confederacy.",1845
+"other","Baker County (1861), named for James McNair Baker, a lawyer and judge who was a Confederate States of America Senator from Florida.[204]",1861
+"other","Bradford County (1861), named for Captain Richard Bradford, who was killed in the Battle of Santa Rosa Island, becoming the first Confederate officer from Florida to die during the Civil War.[204]",1861
+"other","Bartow (1862), previously Reidsville, renamed for CSA Col. Francis Bartow.[206]",1862
+"other","USS General Price (1862) a Confederate ship sunk in battle, raised and used by the Union until sold in 1865.",1862
+"other","Hood County (1866) named for CSA General John Bell Hood",1866
+"other","Bronze plaque commemorating the site of Pettigrew's death.First Confederate Memorial (1867), Romney, West Virginia",1867
+"other","Romney: First Confederate Memorial (1867) Carved on the main facade are the words, ""The daughters of Old Hampshire erect this tribute of affection to her heroic sons who fell in defense of Southern Rights.""",1867
+"other","Confederate Monument to Unknown Soldiers, Old Soldiers' Cemetery, Summer Street at Edwards Street (1869)[399]",1869
+"other","Union City: Confederate Monument (1869)",1869
+"other","City of Forrest City (1870), named for CSA Gen. Nathan Bedford Forrest.[126]",1870
+"other","Lee County (1870)",1870
+"other","City of Cleburne (1871)",1871
+"other","Bolivar: Monument to the Memory of Fallen Confederate Sons (1873)",1873
+"other","Faulkner County (1873), named for CSA Capt. Sandford C. Faulkner.[125]",1873
+"other","Gregg County (1873) named for CSA General John Gregg, who was a delegate to the Texas Secession Convention in 1861 and was elected to represent Texas in the Provisional Confederate Congress in Montgomery, Alabama, and later in Richmond, Virginia. He was killed in action at the Siege of Petersburg in 1864.",1873
+"other","Lee County (1873), named for CSA Gen. Robert E. Lee.[127]",1873
+"other","Titusville (1873), previously Sand Point, renamed by CSA Col. Henry T. Titus, who also supplied Confederate troops.[208]",1873
+"other","Confederate Monument (1874), Greenwood Cemetery[297]",1874
+"other","Lee County (1874) named for Robert E. Lee.",1874
+"other","The Confederate Soldier (1874)[313]",1874
+"other","Town of Stonewall (1874) for Stonewall Jackson",1874
+"other","Battle of Dutton's Hill Monument (1875) on private property, Old Crab Orchard Road.[275] Kentucky Historical Marker at roadside.[d]",1875
+"other","Perry (1875), named for Florida Governor and CSA Col. Madison Starke Perry.[163]",1875
+"other","Tom Green County (1875) named for CSA Brig. Gen. Thomas Green, KIA (killed in action).",1875
+"other","Scotland (St. Mary's County): Confederate Soldiers and Sailors Monument (1876), and Point Lookout Confederate Cemetery Monument (1910), located at Point Lookout Confederate Cemetery.[315] As of October 2018, it is one of 7 cemeteries with Confederate monuments that the Veterans Administration has under 24-hour guard.[240]",1876
+"other","Hemphill County and Hemphill city (1877) named for John Hemphill, Chief Justice of the Texas Supreme Court from 1841 to 1858 until he was elected to the US Senate when Sam Houston refused to support secession. He was expelled from the Senate when Texas seceded in 1861 and then represented Texas in the Provisional Confederate Congress.",1877
+"other","Confederate Memorial (1878), Elmwood Cemetery, 824 Dudley Street[399]",1878
+"other","Leadville: Robert E. Lee Mine (1878)[142][143]",1878
+"other","Confederate monument, on the Plaza de la Constitución (1879).[188] ""The Confederate Memorial Contextualization Advisory Committee, a seven-member task force comprised mostly of historians"", in 2018 recommended to the City Commission that the monument be kept, with the addition of ""some necessary context"".[189]",1879
+"other","Confederate monument, Jackson County Courthouse lawn (1881)",1881
+"other","Frederick: Monument to the Unknown Confederate Soldiers (1881), Mount Olivet Cemetery[320]",1881
+"other","Oldham County (1881) named for William Simpson Oldham Sr., a Confederate politician.",1881
+"other","Columbia: Confederate ""Funeral Rest"" Memorial, Rose Hill Cemetery (1882)[399]",1882
+"other","Donley County (1882) named for Stockton P. Donley, a lawyer who enlisted in the Confederate Army. Just after the war in 1866, he was elected to the Supreme Court of Texas, but was removed by the Reconstruction military government.",1882
+"other","Cleburne County (1883), named for CSA Maj. Gen. Patrick Cleburne.[124]",1883
+"other","Confederate Soldiers Monument (1884); marks the mass burial of 640 Confederate soldiers[115]",1884
+"other","Reeves County (1884) named for CSA officer George R. Reeves.",1884
+"other","Scurry County (1884) named for secessionist and CSA Gen. William Read Scurry.",1884
+"other","Val Verde County (1885) Confederate victory in the Battle of Val Verde",1885
+"other","Army of Tennessee Tomb (1886) at Metairie Cemetery, consisting of a Gothic chapel tomb containing 48 vaults, surmounted by an equestrian statue of Albert Sidney Johnston. A marble statue near the tomb's entrance shows a Confederate sergeant calling the roll. Johnston, P. G. T. Beauregard, and other Confederate soldiers are entombed there.[298]",1886
+"other","Confederate Monument (1886)",1886
+"other","""Armistead's Last Stand"" Marker, for Brig. Gen. Lewis A. Armistead (1887)",1887
+"other","Brewster County (1887) named for Henry Percy Brewster",1887
+"other","City of Granbury (1887)",1887
+"other","Confederate Generals Memorial (1887)[117]",1887
+"other","Jeff Davis County (1887) named for Jefferson Davis.",1887
+"other","Lee County (1887), named for Robert E. Lee.[205]",1887
+"other","Pasco County (1887), named for Samuel Pasco, who fought for the CSA but spent much of the war as a prisoner of war. Pasco later became a state representative and US Senator from Florida.",1887
+"other","Jackson: ""Our Confederate Dead"" Monument (1888)",1888
+"other","Stonewall County (1888) named for CSA General Stonewall Jackson.",1888
+"other","Washington Confederate Monument (1888), Washington Presbyterian Cemetery. Listed on the National Register of Historic Places in 1996.[122][123]",1888
+"other","Ochiltree County (1889) named for secessionist politician William Beck Ochiltree.",1889
+"other","Pensacola: Lee Square (1889) -now Florida Square.",1889
+"other","Randall County (1889) named for CSA Brig. Gen. Horace Randal.",1889
+"other","Reunited Soldiery Monument (1889), one of the first to honor both Confederate and Union soldiers to be placed on a battlefield.[118]",1889
+"other","Roberts County (1889) named for Oran Milo Roberts, who was unanimously elected president of the 1861 Secession Convention, a meeting that he had been influential in calling. In 1862 he resigned the Supreme Court seat and was elected colonel of the Eleventh Texas infantry in the Confederate Army. He was Governor of Texas from 1879 to 1883.",1889
+"other","Student and Soldier Window (1889). Soldier wears gray uniform.",1889
+"other","Sutton County (1890) named for CSA officer John S. Sutton.",1890
+"other","Confederate Memorial Hall Museum (1891), the oldest museum in Louisiana[286]",1891
+"other","Ector County (1891) named for CSA General Mathew Ector, who later served as a judge.",1891
+"other","Foard County (1891) named for Robert L. Foard, an attorney and Confederate Major.[526]",1891
+"other","High Water Mark of the Rebellion Monument (1892)",1892
+"other","Monument to the Confederate dead (1892), Bethel Avenue[399]",1892
+"other","Clarksville: Confederate Monument (1893), Greenwood Cemetery[406]",1893
+"other","Yulee (1893), named for David Levy Yulee, a supporter of slavery and secession. See Levy County, above.",1893
+"other","Gibson Hall at Tulane University (1894), named for Randall L. Gibson",1894
+"other","Chicago: Confederate Mound (1895), Oak Woods Cemetery. Mass grave and monument dedicated to Confederate soldiers who died at Camp Douglas.[243] As of October 2018, the Veterans Administration has it under dawn to dusk guard.[240] It is No. 7 on the Make It Right Project's 2018 list of the 10 Confederate monuments it most wants removed.[244] A counter memorial, a large black granite cenotaph was erected nearby in 1896, dedicated to abolitionists and unionists of the pre-war South.[245][246]",1895
+"other","Covington: Confederate Monument (1895)[399]",1895
+"other","Altamont: Confederate Memorial (1896), depicting flags of the Confederacy[399]",1896
+"other","Louisiana State University is home of the LSU Tigers (1896) and Lady Tigers teams also known as the Fighting Tigers named for the Louisiana Tigers, several Confederate Civil War regiments.[302][303]",1896
+"other","Sherman: Confederate Soldiers' Monument (1896), Grayson County Courthouse. This was the first Confederate statue dedicated at a county courthouse in Texas.[503]",1896
+"other","Denmark: Britton Lane Confederate Monument (1897)",1897
+"other","Fayetteville: Confederate statue (1897), Fayetteville Confederate Cemetery[113]",1897
+"other","Sherman: Confederate Soldier Monument (1897)",1897
+"other","Confederate monument, downtown Hemming Park (1898)[174][32]: 34  ""The president of Jacksonville City Council, Anna Lopez Brosche, called for all Confederate monuments to be moved from city property to a museum. The most prominent Confederate memorial in Jacksonville is a statue of a Confederate soldier that sits atop a towering pillar in Hemming Park.""[175]",1898
+"other","Franklin: ""Our Confederate Soldiers"" Monument (1899), UDC monument known locally as ""Chip"" memorializes soldiers who died in the Battle of Franklin. Since by state law it cannot be removed, the city of Franklin, with ""broad support"", wants to install historic markers ""depicting the experience of the African-Americans before, during, and after the Civil War."" The UDC opposes this, claiming ownership of the Public Square. As of December 2018, the issue is in litigation.[401][402]",1899
+"other","Hemming Park/Hemming Plaza (1899) renamed in honor of Civil War veteran Charles C. Hemming, after he installed a 62-foot (19 m)-tall Confederate monument in the park in 1898.[212][213] -now James Weldon Johnson Park.",1899
+"other","Monticello: Confederate monument, Jefferson County Courthouse (1899)[163][164][32]: 36 ",1899
+"other","Van Buren: Van Buren Confederate Monument (1899)",1899
+"other","Honor and Peace Window (1900). There is no inscription, but a Harvard University page (Memorial Hall) explaining the windows says: ""This window commemorates those who surrendered their lives in the War of the Rebellion."" Portrays two warriors, one with sword high in triumph, one kneeling in defeat, who from the ribbons can be seen to be from different but related countries.",1900
+"other","Humboldt: Confederate Monument (1900), Bailey Park",1900
+"other","Paris: Confederate Monument (1900)",1900
+"other","St. Petersburg: Confederate monument, Greenwood Cemetery (1900)[191]",1900
+"other","Albert Pike Memorial (1901):[146] An outdoor statue that is owned by the National Park Service at 3rd and D Streets NW in the Judiciary Square neighborhood of Washington, D.C. Pike was a Confederate General and leading Freemason and is dressed as a Mason in the sculpture.[57] The statue is a ""portrait of Albert Pike as a Masonic leader and not as a general in the military.""[147][148][149] ""Eight D.C. elected officials have asked the National Park Service to remove"" the statue.[150] On June 19, 2020, protesters tore down the statue and set it on fire as part of the George Floyd protests because of Pike's association with the Confederacy.",1901
+"other","Marshall: Confederate Monument of Saline (1901)",1901
+"other","Rutherford County Confederate Memorial (1901)",1901
+"other","Springfield: Two monuments are located at Springfield National Cemetery: the Monument to Confederate Soldiers of Missouri and General Sterling Price[339] (1901), and a UDC granite marker to the unknown Confederate dead at the Battle of Wilson's Creek (1958).[343] In late August 2017, someone threw paint on it; as of October 2018, it is one of 7 cemeteries with Confederate monuments that the Veterans Administration has under 24-hour guard.[240]",1901
+"other","Union: Monroe County Confederate Soldier Monument (1901); marble statue inscribed ""There is a true glory and a true honor. The glory of duty done, the honor of integrity of principle. R. E. Lee""[570]",1901
+"other","Clarksville: Clarksville Confederate Monument, (1902) The Oakland Cemetery obelisk inscribed, ""Sacred to the memory of our Confederate dead,"" was added to the National Register of Historic Places in 1999.[112]",1902
+"other","Gray County (1902) named for Peter W. Gray, a lawyer and legislator who attended the 1861 Texas State Secession Convention, and voted to leave the union. Shortly after, Gray was elected to the Confederate House of Representatives.",1902
+"other","Confederate Soldiers Monument (1903) features four bronze figures representing the Confederate artillery, cavalry, infantry, and navy. A bronze statue of Jefferson Davis stands above them.[446] The inscription reads: ""Died for state rights guaranteed under the constitution. The people of the South, animated by the spirit of 1776, to preserve their rights, withdrew from the federal compact in 1861. The North resorted to coercion. The South, against overwhelming numbers and resources, fought until exhausted.""[447]",1903
+"other","Erwin: Confederate Memorial, Ohio Avenue (1903)[399]",1903
+"other","Fort Smith: Ft. Smith Confederate Monument (1903)",1903
+"other","Gallatin: Confederate Soldiers Monument (1903)",1903
+"other","Linden: Confederate Monument (1903), Cass County Courthouse[488]",1903
+"other","Reagan County (1903) named for CSA Postmaster General John H. Reagan.",1903
+"other","St. Francisville: Confederate Monument (1903). Has Confederate flag above the inscription: ""In memory of West Feliciana's Confederate dead, wherever at rest. Co. C 1st Regt. La. Cavalry"".",1903
+"other","Evansville: The Confederate monument (1904) at Oak Hill Cemetery marks the burial site of 24 Confederate prisoners who died at Evansville.[250]",1904
+"other","Flag of Maryland (1904). The state flag of Maryland features the red-and-white Crossland Banner, the unofficial state flag of Maryland used by secessionists and Confederates during the American Civil War.[306][307][308][309] The current state flag started appearing after the Civil War as a form of reconciliation. The flag became official in 1904.",1904
+"other","Lewisburg: Confederate Soldier Monument (1904)",1904
+"other","Memorial at Oddfellows Cemetery (1904) near a mass grave[342]",1904
+"other","Terry County (1904) named for CSA Col. Benjamin Franklin Terry .",1904
+"other","Women's Monument to those who kept up the responsibilities of farms and businesses during the Civil War (1904)[399]",1904
+"other","Bonham: Confederate Soldiers' Monument (1905), Fannin County Courthouse[461]",1905
+"other","Confederate Monument (1905)",1905
+"other","Confederate Soldiers Monument, also known as Defense of the Flag, Arkansas State Capitol grounds, (1905).[105]",1905
+"other","Monument to Confederate Soldiers (1905)",1905
+"other","Terrell County (1905) named for CSA acting General Alexander W. Terrell.",1905
+"other","Civil War Memorial in memory of the three thousand Confederate soldiers of Lincoln County (1906)",1906
+"other","Confederate Memorial (1906) Originally at Fairview Cemetery.",1906
+"other","Confederate Monument (1906)",1906
+"other","Higginsville: Confederate Memorial State Historic Site; also called ""Lion of Lucerne"" (1906)",1906
+"other","Lewisburg: Confederate Monument (1906) The Confederate ""monument was erected by the United Daughters of the Confederacy at a cost of $2,800. The monument was originally located on the campus of the Greenbrier College, but moved to its present location when U.S. Route 60 was relocated.""[565] It is now located on the lawn of the old public library in Lewisburg. Some residents have suggested interpretive signage for the statue.[566] The inscription on the base reads, ""In memory of our Confederate dead.""[567]",1906
+"other","Marshall: Confederate Soldiers' Monument (1906), Harrison County Courthouse[497]",1906
+"other","Pulaski: ""Rebel Martyr"" Sam Davis Statue (1906)",1906
+"other","Tampa: Lee Elementary School of Technology / World Studies (1906). The school's mascot is Robert E. Lee's horse Traveller. In July 2015, students asked the school board to change the school's name.[225] In June 2017, a board member asked the board to consider the name change.[226] -now Tampa Heights Elementary School",1906
+"other","Batesville: Batesville Confederate Monument (1907)",1907
+"other","Corsicana: Call to Arms (Confederate Soldiers' Monument), by Louis Amateis (1907), Navarro County Courthouse.[464][465] A Civil War bugler stands in uniform holding a bugle to his mouth with his proper right hand. He holds a sword in his proper left hand at his side. He wears a hat with a feather in it and knee-high boots. A bedroll is slung over his proper left shoulder and strapped across his chest and proper right hip. The sculpture is mounted on a rectangular base.[466] ""Isaac O'Haver was a member of Co K of the 17th VA Cavalry. He was a 17 year-old bugler for his unit. He was born Sep. 20, 1844 and died at the age of 27 on March 30, 1872. He is buried at the Ladoga Cemetery.""[467] The plaques on the monument read:",1907
+"other","Jackson County (1907) sources dispute if the name is for the CSA General or President Jackson",1907
+"other","Lt. Gen. James Longstreet Headquarters Marker (1907)",1907
+"other","Mount Pleasant: Confederate Monument (1907)",1907
+"other","Palmyra: Palmyra Massacre Monument (1907).",1907
+"other","Roger Mills County (1907), named for Roger Q. Mills, Confederate colonel and later Congressman and U.S. Senator.",1907
+"other","Tangipahoa Parish: Confederate monument (1907) at Camp Moore, a museum and former Confederate training camp[300]",1907
+"other","Terry's Texas Rangers Monument, a monument ""to memorialize those [who] fought for the Confederacy""[448] (1907).",1907
+"other","Army of Northern Virginia Marker (1908)",1908
+"other","Bentonville: Bentonville Confederate Monument (1908); UDC monument[111]",1908
+"other","Gainesville Confederate Heroes Statue (1908) in Leonard Park[517][518]",1908
+"other","Parkersburg: Confederate Soldier Monument, (1908) The monument was created by Leon Hermant and the inscription reads in part, "" IN MEMORY OF OUR CONFEDERATE DEAD ERECTED BY PARKERSBURG CHAPTER UNITED DAUGHTERS OF CONFEDERACY""[569]",1908
+"other","Alton: UDC monument (1909), North Alton Confederate Cemetery. Dedicated to Confederate soldiers who died at Alton Military Prison[239] As of October 2018, it is one of 7 cemeteries with Confederate monuments that the Veterans Administration has under 24-hour guard.[240]",1909
+"other","Brownsville: Confederate Memorial (1909)",1909
+"other","Clinton: Confederate Monument (1909)",1909
+"other","Confederate Monument, Kiwanis Park (1909)",1909
+"other","Confederate Private Monument (1909) in Centennial Park.",1909
+"other","El Dorado: El Dorado Confederate Monument (1909)",1909
+"other","Galveston: Dignified Resignation (1909) by Louis Amateis at the Galveston County Courthouse. With his back turned to the US flag while carrying a Confederate flag, it is the only memorial in Texas to feature a Confederate sailor.[478][479] It was ""erected to the soldiers and sailors of the Confederate States of America."" An inscription on the plaque reads, ""there has never been an armed force which in purity of motives intensity of courage and heroism has equaled the army and navy of the Confederate States of America.""[447]",1909
+"other","Graves County: Camp Beauregard Memorial (1909), Camp Beauregard Cemetery. UDC memorial to Confederate soldiers who died at Camp Beauregard ""for the Confederate State of America and were denied the glory of heroic service in a battle"".[264]",1909
+"other","Madison: Confederate monument, Four Freedoms Park (1909). Lists names of men who died from county. Nearby sits a monument to former slaves in the county.[163][32]: 35 ",1909
+"other","Mulberry: Confederate Memorial (1909)",1909
+"other","West Alton: Confederate Memorial, Lincoln Shields Recreation Area (1909).[345]",1909
+"other","Benton: Confederate Soldier Monument (1910)",1910
+"other","Confederate Monument (1910) at Oklahoma Veterans Center (formerly Oklahoma Confederate Home) has pair (CSA and Union) monuments.[379]: 14 ",1910
+"other","Confederate Monument (1910), Finn's Point National Cemetery.There are at least two public spaces dedicated to the Confederacy in New Jersey.",1910
+"other","Confederate Soldier Memorial, Camp Chase, ColumbusThe Lookout (1910), Johnson's Island, Ottawa County[372]",1910
+"other","Confederate Soldiers' Monument (1910)[456]",1910
+"other","Jackson Elementary School (1910)[387] -now Mary Golda Ross Enterprise Elementary School.",1910
+"other","Lake Village: Lake Village Confederate Monument (1910)",1910
+"other","Lonoke: Lonoke Confederate Monument (1910)",1910
+"other","Pennsville Township: Confederate Monument (1910), Finn's Point National Cemetery. Commemorates the 2,436 Confederate prisoners-of-war who died at Fort Delaware.[353] As of October 2018, it is one of 7 cemeteries with Confederate monuments that the Veterans Administration has under 24-hour guard.[240]",1910
+"other","Pine Bluff Confederate Monument (1910)",1910
+"other","Robert E. Lee Elementary School (1910)[387] -now Adelaide Lee Elementary School.",1910
+"other","Scotland (St. Mary's County): Confederate Soldiers and Sailors Monument (1876), and Point Lookout Confederate Cemetery Monument (1910), located at Point Lookout Confederate Cemetery.[315] As of October 2018, it is one of 7 cemeteries with Confederate monuments that the Veterans Administration has under 24-hour guard.[240]",1910
+"other","Statue of Stonewall Jackson by Moses Ezekiel[557] on the State Capitol grounds (1910) placed by UDC Chapter No. 151[558][559]",1910
+"other","Upton County (1910) named for brothers John C. and William F. Upton, both colonels in the Confederate Army.",1910
+"other","Wheeler Elementary School (1910)[387]",1910
+"other","Winkler County (1910) named for CSA Col. Clinton M. Winkler.",1910
+"other","Arkadelphia: Arkadelphia Confederate Monument (1911)",1911
+"other","Cleveland: United Daughters of the Confederacy Monument (1911)[32]: 191 ",1911
+"other","Culberson County (1911) named for CSA Lieutenant Colonel David B. Culberson",1911
+"other","Gainesville: Confederate Soldiers' Monument, Cooke County Courthouse (1911)[480][481][454][482]",1911
+"other","Longview: Confederate Soldiers' Monument (1911), Gregg County Courthouse[492][493]",1911
+"other","Memorial to Company A Confederate Soldiers (1911)",1911
+"other","Palestine: John H. Reagan Memorial (1911) by Pompeo Coppini[478]",1911
+"other","Philadelphia: Confederate Soldiers and Sailors Monument (1911), Philadelphia National Cemetery. Commemorates 184 Confederate prisoners of war who died in Philadelphia area hospitals and camps.",1911
+"other","Seventh Kentucky Mounted Infantry Memorial (1911)",1911
+"other","Union Confederate Monument, Union Cemetery (1911)",1911
+"other","Virginia State Monument (1917), Gettysburg Battlefield.Confederate Soldiers and Sailors Monument (1911), Philadelphia National Cemetery.",1911
+"other","Battlefield monument, Olustee Battlefield Historic State Park (1912). Inscription: Here was fought on February 20, 1864, the Battle of Ocean Pond under the immediate command of General Alfred Holt Colquitt, ""Hero of Olustee."" This decisive engagement prevented a Sherman-like invasion of Georgia from the south. Erected April 20, 1936, by the Alfred Holt Colquitt Chapter, United Daughters of the Confederacy Ga. Div.",1912
+"other","Beaumont: ""Our Confederate Soldiers"" Monument (1912). Removed in June 2020.[513]",1912
+"other","CSA Brigadier General Joseph Finnegan Monument, Olustee Battlefield Historic State Park (1912). ""Placed by The United Daughters of the Confederacy Florida Division In Memory of Brig. Gen. Joseph Finegan Commander of the District of Middle and East Florida So well did he perform his part that a signal victory over the Federals was won in the Battle of Olustee Feb. 20, 1864""",1912
+"other","Clarksville: Confederate Soldier Monument (1912)",1912
+"other","Confederate Memorial Gen. Hatton Statue (1912)",1912
+"other","Fort McHenry Monument (1912), dedicated to Confederate soldiers who died at Fort McHenry, when it was a prisoners-of-war camp.[314]",1912
+"other","General Robert Hopkins Hatton marker (1912)[399]",1912
+"other","Jefferson Davis Parish (1912)",1912
+"other","Mount Pleasant: Confederate Soldiers' Monument (1912), Titus County Courthouse[494][495]",1912
+"other","Nathan Bedford Forrest Memorial Tablet (1912)",1912
+"other","Tallulah: Confederate Monument (1912)",1912
+"other","Terre Haute: Woodlawn Monument Site (1912), Woodlawn Cemetery. Erected by the Federal Government to commemorate 11 Confederate soldiers who died in a local prison camp.[255]",1912
+"other","Victoria: Confederate Monument (1912). Pompeo Coppini's statue, called The Last Stand, and sometimes The Firing Line, sits in De Leon Plaza. The inscription reads: ""On civilization's height / Immutable they stand"". The $5,000 cost was raised by the United Daughters of the Confederacy.",1912
+"other","Waxahachie: Confederate Soldiers' Monument (1912), Ellis County Courthouse[510][511]",1912
+"other","Bay City: Confederate Soldiers' Monument (1913), Matagorda County Courthouse[458][459]",1913
+"other","Beauregard Parish (1913)",1913
+"other","Confederate Monument at Cherokee National Capitol (1913).[379] Removed in 2020.[384]",1913
+"other","Franklin: Confederate Monument (1913)",1913
+"other","Granbury: Statue of CSA General Hiram B. Granbury (1913), killed in the Battle of Franklin (1913), Hood County Courthouse. Erected by UDC.[484]",1913
+"other","Little Rock Confederate Memorial (1913)[116]",1913
+"other","Monument to Confederate Women (or ""Mother of the South""), Arkansas State Capitol grounds, Little Rock, Arkansas. Statue depicts a mother and daughter saying good-bye to their 16-year-old son and brother who is leaving to join his father in the fighting. (1913)[106][107]",1913
+"other","Alexandria: Rapides Parish Confederate Monument (1914)",1914
+"other","Forrest City High School (1914)",1914
+"other","Jacksonport: Jackson County Confederate Memorial (1914)",1914
+"other","Plaquemine: Confederate Memorial (1914)",1914
+"other","Camden: Camden Confederate Monument (1915)",1915
+"other","Dresden: Weakley County Confederate Monument (1915)",1915
+"other","Florida's Tribute to the Women of the Confederacy, in Confederate Park (1915). The sculptor was Allen George Newman.[173]",1915
+"other","Keytesville: Price Park memorializes Major General Sterling Price. (1915)",1915
+"other","Keytesville: Sterling Price Monument, Price Park (1915)",1915
+"other","Lake Charles: South's Defenders Monument (1915); knocked from its pedestal by Hurricane Laura[288]",1915
+"other","Brooksville: Confederate Soldiers' Memorial, Hernando County Courthouse (1916)[162][32]",1916
+"other","Georgetown: Confederate Soldiers and Sailors Monument, Williamson County Courthouse (1916)",1916
+"other","Adolph Meyer School (1917), New Orleans, named for Confederate general Adolph Meyer who served nine terms in the U.S. House of Representatives and advocated for the construction of the Algiers Naval Station across the street from where the school was later built. The school was renamed in the 1990s for Harriet Tubman.",1917
+"other","Farmersville: Confederate Soldier Monument (1917), Farmersville City Park[516]",1917
+"other","Fort Benning (1917), near Columbus, Georgia, named for Confederate General Henry L. Benning, was redesignated Fort Moore on 11 May 2023 in honor of General Hal Moore and his wife Julia Compton Moore[83] However, it was redesignated as Fort Benning again in 2025.[84]",1917
+"other","Fort Gordon (1917), near Augusta, Georgia, named for Confederate General John Brown Gordon, was redesignated as Fort Eisenhower on 27 October 2023 in honor of president Dwight D. Eisenhower[81][86]",1917
+"other","Fort Lee (1917), in Prince George County, Virginia, named after Confederate General Robert E. Lee, was redesignated Fort Gregg-Adams on 27 April 2023 in honor of Lieutenant General Arthur J. Gregg and Lieutenant Colonel Charity Adams[88]",1917
+"other","Gen. Robert E. Lee Equestrian Statue (1917), atop the Virginia State Monument",1917
+"other","Osceola: Searcy Confederate Monument (1917)[106]",1917
+"other","Virginia State Monument (1917), Frederick William Sievers, sculptor. Features a larger-than-life sculpture group, ""Virginia to Her Sons at Gettysburg;"" and is topped by an equestrian statue of Gen. Robert E. Lee. The National Park Service says the monument will not be removed.[390]",1917
+"other","Virginia State Monument (1917), Gettysburg Battlefield.Confederate Soldiers and Sailors Monument (1911), Philadelphia National Cemetery.",1917
+"other","Fort Bragg (1918), in North Carolina, named for Confederate General Braxton Bragg, was redesignated Fort Liberty on 2 June 2023 in honor of Liberty.[85] On 14 February 2025, it was again renamed to Fort Bragg, though this time under the namesake of U.S. Army paratrooper Roland L. Bragg from World War II, who holds no relation to Braxton Bragg.",1918
+"other","Texarkana: The Confederate Mothers Monument (1918), located in Texas near the state line with Arkansas, is shared by the US District Court in Texarkana, Texas, and the US Post Office and Courthouse in Texarkana, Arkansas[506][507]",1918
+"other","Chattanooga: statue of Alexander P. Stewart, a confederate lieutenant, in front of the Chattanooga/Hamilton County Courthouse. (1919) Efforts have been made to remove this statue.[405]",1919
+"other","Gen. Robert E. Lee Headquarters Marker (1920)",1920
+"other","Lt. Gen. Ambrose P. Hill's Headquarters Marker (1920)",1920
+"other","Lt. Gen. Richard S. Ewell's Headquarters Marker (1920)",1920
+"other","Opelousas: Confederate Monument (1920)",1920
+"other","Dardanelle: Dardanelle Confederate Monument (1921)",1921
+"other","Russellville: Confederate Mothers Memorial Park (1921). Land for the public park was donated by UDC and includes three stone monuments, each one placed by a different Confederate veterans or memorial organization, honoring the mothers of the Confederacy.[128]",1921
+"other","Cleburne: Cleburne Monument (2015) Confederate Arch (1922)",1922
+"other","Lafayette: Brig. Gen. J.J. Alfred A. Mouton Statue (1922). There was considerable local discussion about what to do with the monument.[294][295] Removed on July 18, 2021.[296]",1922
+"other","Woodville: In Loving Memory Monument, Natural Bridge Battlefield Historic State Park (1922)[32]: 37  A plaque placed at the base of the monument in 2000 lists the names of those who died as a result of the battle.[193]",1922
+"other","David O. Dodd Memorial (1923)",1923
+"other","Hendry County (1923), named for Francis Asbury Hendry, a Confederate Captain and one of the first settlers in the area.[204]",1923
+"other","Oklahoma City: Confederate Monument in Fairlawn Cemetery (1923)[379]",1923
+"other","Battle of Marianna Monument, Jackson County Courthouse lawn (1924)[163][32]: 36 ",1924
+"other","Confederate memorial pavilion at Bayview Park (1924) by UDC.[178]",1924
+"other","Kirby-Smith Middle School (1924), named for CSA Gen. Edmund Kirby Smith. -now Springfield Middle School.",1924
+"other","Conway: Conway Confederate Monument (1925)",1925
+"other","Ellenton: Judah P. Benjamin Confederate Memorial at Gamble Plantation Historic State Park (1925)[209]",1925
+"other","Davis High School (1926). In 2016, the Houston school board voted to rename the school.[541] -now Northside High School.",1926
+"other","Greenville: Confederate Soldier Monument (1926)",1926
+"other","John H. Reagan High School (1926). In 2016, the Houston school board voted to rename the school.[541] -now Heights High School.",1926
+"other","Nashville: Tennessee Confederate Women's Monument, Belle Kinney Scholz, sculptor (1926)",1926
+"other","Star City: Star City Confederate Memorial (1926) Erected on the courthouse grounds, moved in 1943 and moved again to its original position, now the town square, in the 1990s. Consists of a statue of a Confederate soldier.[106]",1926
+"other","United Confederate Veterans Civil War Plaques (1926)[399]",1926
+"other","Winnfield: Confederate Monument (1926)",1926
+"other","Shreveport: Fort Humbug Confederate Memorial (1927)",1927
+"other","Blountville: Confederate Memorial (1928)[399]",1928
+"other","Gen. Thomas J. Churchill Memorial (1928)",1928
+"other","Gen. William Read Scurry Memorial (1928)",1928
+"other","Grant County: UDC monument (1928) at Jenkins' Ferry Battleground State Park to Confederate soldiers who died at the Battle of Jenkins' Ferry[114]",1928
+"other","Lake City: Confederate Dead of Battle of Olustee, town square in front of the Columbia County Courthouse (1928)[180]",1928
+"other","Lee High School (1928)",1928
+"other","Robert E. Lee High School (1928) -now Riverside High School.",1928
+"other","North Carolina State Monument (1929), Gutzon Borglum, sculptor. Borglum was also the first sculptor on the Stone Mountain#Confederate Memorial Carving project.",1929
+"other","Weatherford: Confederate Soldiers' Monument (1929), Parker County Courthouse[509]",1929
+"other","Stand Watie Elementary School (1930)[387] -now Esperanza Elementary School.",1930
+"other","Zachary: Port Hudson Confederate Monument (1930)",1930
+"other","Breckinridge's March Monument (1931)",1931
+"other","Cape Girardeau: Confederate War Memorial (1931)",1931
+"other","Harpers Ferry: Heyward Shepherd Monument (1931). Although Shepherd was a black freeman working for the railway when killed in John Brown's raid on Harper's Ferry, the monument was erected by UDC and Sons of Confederate Veterans (SCV). They called the project the ""Faithful Slave Memorial"" for many years and saw it as a way to emphasize their idea that blacks enjoyed being slaves and that men like Shepherd were victims of those seeking to free slaves.[562]",1931
+"other","Defenders Memorial Plaque (1932)[109]",1932
+"other","Alabama State Monument (1933), Joseph Urner, sculptor.",1933
+"other","Dover: Confederate Monument, Fort Donelson (1933)[399]",1933
+"other","Minden: Confederate Monument (1933)",1933
+"other","Blytheville: Confederate War Memorial (1934)",1934
+"other","Gov. Francis T. Nicholls Statue (1934). Nicholls was a brigadier general in the Confederate Army.",1934
+"other","Gov. Henry Watkins Allen Statue (1934). Allen was a brigadier general in the Confederate Army. He is buried on the Old Louisiana State Capitol grounds.",1934
+"other","Hot Springs Confederate Monument (1934)",1934
+"other","Lee College (1934) Lee College dropped “Rebels” as their nickname/mascot, and rebranded as “Navigators” in 2022.[539]",1934
+"other","Centralia: Boone County Confederate Memorial (1935)",1935
+"other","Columbia: Confederate Monument (1935). Relocated to the Centralia Battlefield in September 2015.",1935
+"other","Confederate Bench (1936)",1936
+"other","Marion, Crittenden County: Civil War Memorial (1936)",1936
+"other","Confederate Veterans Memorial Monument, Gamble Plantation Historic State Park (1937)[32][169]",1937
+"other","Elmira: UDC monument (1937) at Woodlawn National Cemetery, dedicated to Confederate soldiers who died in Elmira Prison.[366] As of October 2018, it is one of 7 cemeteries with Confederate monuments that the Veterans Administration has under 24-hour guard.[240]",1937
+"other","Fort Smith: Jefferson Davis Memorial (1937)",1937
+"other","New Braunfels: Confederate Soldiers' Monument (1937), Comal County Courthouse[498]",1937
+"other","Shelbyville: Confederate Memorial in Memory of the ""Shelbyville Rebels"" Company F 41st Tennessee Regiment CSA (1937)[32]: 205 ",1937
+"other","Davis Mountains State Park (1938) named for the mountain range",1938
+"other","Fort Worth: Confederate Soldier Memorial (1939), Oakwood Cemetery[478]",1939
+"other","J.J. Finley Elementary School (1939), named for CSA Brig. Gen. Jesse J. Finley.[219] -now Carolyn Beatrice Parker Elementary School.",1939
+"other","Kirby-Smith Center (1939), Alachua County Public Schools administrative offices. Constructed in 1900, the building was initially the all white Gainesville Graded & High School.[220] In August 2017, the school board announced plans to rename the center.[221]",1939
+"other","Stonewall Jackson Elementary School (1939) – now Mockingbird Elementary School.",1939
+"other","Homer: Confederate Monument (1940)",1940
+"other","Oktaha: Memorial in Oktaha Cemetery to Confederate soldiers who died in the Battle of Honey Springs (1940)[379]",1940
+"other","Fort A.P. Hill (1941), near Bowling Green, Virginia, named for Confederate General A. P. Hill, was redesignated Fort Walker on 25 August 2023 in honor of Medal of Honor recipient and civilian army surgeon Dr. Mary Edwards Walker[81][82]",1941
+"other","Fort Polk (1941), near Leesville, Louisiana, named for Episcopal bishop and Confederate General Leonidas Polk, was redesignated Fort Johnson on 13 June 2023 in honor of Medal of Honor recipient Sergeant William Henry Johnson[81][90]",1941
+"other","The Hermitage: UDC monument and gates (1941) at the Tennessee Confederate Soldiers Cemetery[413]",1941
+"other","Fort Hood (1942), in Killeen, Texas, formerly named after Confederate General John Bell Hood, was redesignated Fort Cavazos on 9 May 2023 in honor of General Richard Cavazos[87]",1942
+"other","Fort Pickett (1942), near Blackstone, Virginia, a Virginia National Guard installation named for Confederate General George Pickett, was redesignated Fort Barfoot on 24 March 2023 in honor of Medal of Honor recipient Colonel Van T. Barfoot[89]",1942
+"other","Fort Rucker (1942), in Dale County, Alabama, named for Confederate Colonel Edmund Rucker, was redesignated Fort Novosel on 10 April 2023 in honor of Medal of Honor recipient Chief Warrant Officer 4 Michael J. Novosel[91]",1942
+"other","Hornbrook (1944)",1944
+"other","Grand Prairie: Robert E. Lee Elementary School (1948) -now Delmas F. Morton Elementary School.",1948
+"other","Thibodaux: Nicholls State University (1948), named for CSA Brig. Gen. Francis Redding Tillou Nicholls. The school's mascot, Colonel Tillou, is also named for Nicholls.[305]",1948
+"other","San Angelo: Lee Middle School (1949)-now Lone Star Middle School.",1949
+"other","UDC Memorial to Confederate soldiers (1950), City Cemetery",1950
+"other","Springdale: Robert E. Lee Elementary School (1951)",1951
+"other","Yellow Bluff Fort Monument, Yellow Bluff Fort Historic State Park (1951)[176]",1951
+"other","Clarksburg: Bronze equestrian statue of Stonewall Jackson created by Charles Keck (1953) by the United Daughters of the Confederacy (UDC). Jackson was born in Clarksburg.",1953
+"other","Fort Worth: Monument to ""Confederate Soldiers and their Descendents"" (1953), Tarrant County Courthouse[477]",1953
+"other","Montgomery County: A passenger and vehicle ferry, formerly named Gen. Jubal A. Early (1954), connected Montgomery County, Maryland, and Loudoun County, Virginia. Owned by White's Ferry, it was named for Confederate General Jubal Early until June 2020 when it was renamed Historic White's Ferry.[332] White's Ferry was the only ferry still in operation on the Potomac River until it ceased operations in Dec 2020.[333][334]",1954
+"other","Kitchener, Ontario: Eastwood Collegiate Institute (1956), a public high school, replaced its Johnny Rebel mascot and Confederate imagery, perceived as associated with white bigotry, with Rebel Lion in 1999. The school retains the Rebel name for its teams.[citation needed]",1956
+"other","Fairview: Jefferson Davis State Historic Site (1957) the site includes Davis's birthplace, a memorial to Davis that includes a 341 ft obelisk (the second tallest obelisk in the world after the Washington Monument), Confederate flags and other signs and plaques.[279]",1957
+"other","Deland: Confederate Veteran Memorial, Oakdale Cemetery (1958)[198]",1958
+"other","Robert E. Lee High School (1958). Called ""the city's most radioactive Confederate symbol,"" the possible renaming of the school was the subject of active discussion at meetings in August and September 2017. In 1970, as a result of a statewide federal desegregation order, the school had to get rid of ""its Confederate-themed mascot (the Rebels), fight song (""Dixie""), and prized Confederate flag (so large that it required twenty boys to carry). Its beloved Rebel Guard, a squadron of boys handpicked by an American-history teacher to dress in replica Confederate uniforms at football games and fire a cannon named Ole Spirit after touchdowns, had to find a new name. Same for the Rebelettes drill team.""[546] -now Tyler Legacy High School.",1958
+"other","San Antonio: Robert E. Lee High School (1958). After voting against a name change in 2015, the school board voted in August 2017 to change the name of the school.[544] In October, district trustees voted 5-2 to name the school Legacy of Educational Excellence, or LEE High School.[545] Its mascot is currently the Volunteer and the school colors are red and grey. Its pep squad, currently called the Southern Belles, were once called the Confederates. Its varsity dance team and junior varsity drill team are respectively named the Rebel Rousers and Dixie Drillers.[447]",1958
+"other","Springfield: Two monuments are located at Springfield National Cemetery: the Monument to Confederate Soldiers of Missouri and General Sterling Price[339] (1901), and a UDC granite marker to the unknown Confederate dead at the Battle of Wilson's Creek (1958).[343] In late August 2017, someone threw paint on it; as of October 2018, it is one of 7 cemeteries with Confederate monuments that the Veterans Administration has under 24-hour guard.[240]",1958
+"other","Bust of Stonewall Jackson (born in West Virginia, at that time part of Virginia) by Bryant Baker, located ""in the rotunda of the West Virginia State Capitol."" (1959)[556]",1959
+"other","Johnston Middle School (1959), named for Albert Sidney Johnston. In 2016, the Houston school board voted to rename the school.[541] -now Meyerland Performing and Visual Arts Middle School.",1959
+"other","Port Arthur: Lee Elementary School (1959)-now Lakeview Elementary School.",1959
+"other","Anaheim: Savanna High School (1961) mascot has always been Johnny Rebel and a fiberglass statue of a Confederate soldier stood in the courtyard from 1964 until 2009[133] when it was removed due to deterioration. The school colors are red and grey and the school fields the Savanna Mighty Marching Rebel Band and Color Guard.",1961
+"other","Confederate Sun Dial Monument (1961)[32] Originally a marble base and column topped with a sundial (by the early 1980s all that remained was its base and its bronze plaque). Dedicated to the Confederate dead. Erected by United Daughters of the Confederacy in 1961. Plaque was removed by the City of Daytona Beach in 2017 after violent clashes in Charlottesville, Virginia over their Robert E. Lee monument. Was to be given to Halifax Historical Museum.[167]",1961
+"other","Georgia State Monument (1961)",1961
+"other","Jefferson Davis Middle School (1961) -now Charger Academy.",1961
+"other","Lee Elementary School (1961) -now Robert and Sammye Stafford Elementary School.",1961
+"other","Lee Freshman High School (1961) – now Midland Freshman High School.",1961
+"other","Lee High School (1961). The school's athletic teams are nicknamed the ""Rebels"". Lee High School had used the Confederate flag in the past.[542] -now Legacy High School.",1961
+"other","Mayes County: Confederate Monument at site of Second Battle of Cabin Creek (1961)[379]",1961
+"other","De Ridder: East Beauregard High School (1962)",1962
+"other","Lee Barracks, named for CSA Gen. Robert E. Lee (1962), at U.S. Military Academy at West Point, New York.[92]",1962
+"other","Marthaville: Rebel State Historic Site (1962)",1962
+"other","Port Allen: Henry Watkins Allen Statue (1962)",1962
+"other","Alpine: CSA Gen. Lawrence ""Sul"" Ross Monument (1963)",1963
+"other","Alpine: Confederate Colonel Henry Percy Brewster (1963)[455]",1963
+"other","Aspermont: Historical marker, ""County Named for Confederate Hero Stonewall Jackson"", Stonewall County Courthouse (1963)",1963
+"other","Coleman: Hometown of Texas CSA Col. James E. McCord Monument (1963)",1963
+"other","Confederate Capitol of Missouri Monument (1963)",1963
+"other","Eva: Nathan Bedford Forrest State Park (1963)",1963
+"other","Florida State Monument (1963)",1963
+"other","Historical marker, ""Home Town of Texas Confederate Major Joseph D. Sayers"" (1963)[457]",1963
+"other","Home of Last Texas Confederate Gov. Pendleton Murrah Monument (1963)",1963
+"other","Kermit: Col. C.M. Winkler Monument (1963)",1963
+"other","Miami: Col. O.M. Roberts Monument (1963)",1963
+"other","Snyder: marker (1963) commemorating William Read Scurry, Scurry County Courthouse[504]",1963
+"other","South Carolina State Monument (1963)",1963
+"other","Athens: Henderson County Confederate Monument (1964)",1964
+"other","CSA Maj. Simeon Hart Monument (1964)",1964
+"other","Hometown of Texas CSA Capt. James W. Magoffin Monument (1964)",1964
+"other","Hubbard Middle School (1964), named for Confederate Col. Richard B. Hubbard",1964
+"other","Prescott: Confederate War Memorial (1964)",1964
+"other","Texas Memorial, Pea Ridge City Park (1964).[119]",1964
+"other","Texas State Monument (1964)",1964
+"other","John H. Reagan Early College High School (1965) – now Northeast Early College High School.",1965
+"other","Soldiers and Sailors of the Confederacy Monument (1965), Donald De Lue, sculptor",1965
+"other","Arkansas State Monument (1966)",1966
+"other","Jacksonville[223]J.E.B. Stuart Middle School (1966), named for CSA Gen. J. E. B. Stuart. -now Westside Middle School.",1966
+"other","Tomball: Confederate Powder Mill Marker Monument (1966)",1966
+"other","Belle Chasse: Judah P. Benjamin Monument (1968)",1968
+"other","Dowling Middle School (1968), named for CSA Maj. Richard W. Dowling. In 2016, the Houston school board voted to rename the school.[541] -now Audrey H. Lawson Middle School.",1968
+"other","Marthaville: Unknown Confederate Soldier Monument (1970)",1970
+"other","Louisiana State Monument (1971), Donald De Lue, sculptor",1971
+"other","Stand Watie Monument (1971).[379] Removed in 2020.[384]",1971
+"other","Confederate monument Riverside Cemetery, Denver (1973)[141]",1973
+"other","Mississippi State Monument (1973), Donald De Lue, sculptor",1973
+"other","Huntsville: Captain Delaney S. Washburn Memorial (1976).",1976
+"other","Smith County War Memorial (1976)[399]",1976
+"other","Confederate Boulder Monument (1979)[32]: 33 ",1979
+"other","Bartow: 7th Florida Infantry Regiment Monument, Old Polk County Courthouse (1982)[161]",1982
+"other","Tennessee State Monument (1982)",1982
+"other","Confederate Soldiers Monument (1983) in Honey Springs Battlefield by UDC and Children of the Confederacy.[379]",1983
+"other","Johnson Bayou: Robert E. L Statue (1984)",1984
+"other","Harrison: Boone County Confederate Veterans Memorial, on the grounds of the Boone County Courthouse (1986)",1986
+"other","Confederate Monument (1987): This white obelisk is located in Hudson Park. It is inscribed on one side with an image of a Confederate flag and the words: ""1861–1865. In loving memory of those from Wakulla County who served the Confederacy during the war between the states. Erected by the R. Don McLeod Chapter 2469 United Daughters of the Confederacy May 17, 1987.""",1987
+"other","Denton: Lee Elementary School (1988), renamed Alice Moore Alexander Elementary School in 2017",1988
+"other","Memorial to the Confederate Dead, Jefferson Barracks National Cemetery (1988)[344]",1988
+"other","Spencer: Confederate Monument (1988)",1988
+"other","Weston: Stonewall Jackson Lake State Park (1990) named for Stonewall Jackson Lake named for Confederate General Stonewall Jackson.",1990
+"other","Seal of TexasThe reverse side of the Seal of Texas (1992) includes ""the unfurled flags of the Kingdom of France, the Kingdom of Spain, the United Mexican States, the Republic of Texas, the Confederate States of America, and the United States of America"". The Confederate flag is rendered as the Stars and Bars.",1992
+"other","Samuel Garland, Jr. Monument (1993)[318]",1993
+"other","Santa Fe: Confederate memorial (1993), Santa Fe National Cemetery. Granite and bronze memorial dedicated to 31 Confederate soldiers discovered in shallow graves in 1987 at Glorieta Pass Battlefield, then re-interred at Santa Fe National Cemetery.[356][357]",1993
+"other","Lieutenant Gen. Richard Taylor memorial (1994) outside Pleasant Hill American Legion Hall[291]",1994
+"other","Maryland State Monument (1994). Honors Maryland soldiers on both the Union and Confederate sides.",1994
+"other","Red River Campaign memorial (1994)[292]",1994
+"other","Selmer: Confederate Memorial (1994)",1994
+"other","Martin, David G. (1995). Confederate Monuments at Gettysburg. Da Capo Press. ISBN 978-0938289487.",1995
+"other","Savannah: Confederate Monument (1995)",1995
+"other","Dexter: Frenchman's Spring Monument (1996). A natural gathering place for soldiers. In July 1861, 2,000 soldiers from 15 southeast Missouri counties met to organize as the First Division, Missouri State Guard – the pro-Confederate state militia, known as the Swamp Fox Brigade.",1996
+"other","Smithville: Confederate War Memorial (1996)[120]",1996
+"other","Smithville: DeKalb County Confederate Monument (1996)",1996
+"other","Gelbert, Doug (1997). Civil War sites, memorials, museums, and library collections : a state-by-state guidebook to places open to the public. Jefferson, North Carolina: McFarland & Co. ISBN 0786403195.",1997
+"other","Roanoke: Shelby's Homecoming Monument (1997)",1997
+"other","Savage, Kirk (1997). Standing Soldiers, Kneeling Slaves: Race, War, and Monument in Nineteenth-century America. Princeton, NJ: Princeton University Press. ISBN 978-0691009476. OCLC 36470304.",1997
+"other","As of June 29, 2020[update], there is at least one known public monument of a confederate soldier in Michigan. It is located in Allendale, Michigan, a town in Ottawa County. A part of the Veterans Garden of Honor (1998) which features nine life sized statues of soldiers from various wars, the statue in question depicts a union soldier and a confederate soldier back to back with a young slave at their feet holding a plaque reading ""Freedom to Slaves,"" and the date January 5, 1863.[336]",1998
+"other","Covington: Nathan Bedford Forrest Memorial, Tipton County Museum (1998)[399]",1998
+"other","Lt. Gen. James Longstreet Equestrian Statue (1998)",1998
+"other","Donaldsonville: Fort Butler Memorial (1999)",1999
+"other","Holliday: Stonewall Jackson Camp 249 Monument (1999)",1999
+"other","Gary W. Gallagher; Alan T. Nolan (2000). The Myth of the Lost Cause and Civil War History. Indiana University Press. ISBN 978-0253338228.",2000
+"other","Tazewell: Confederate memorial (2000) honoring unknown Confederate dead; located in Irish Memorial Cemetery.[399]",2000
+"other","Brookline: Missouri State Guard Monument (2001)",2001
+"other","Confederate Monument (2001): ""Confederate Veterans Memorial honoring those from Dickson County who served the CSA.""",2001
+"other","East Beauregard Elementary School (2001)",2001
+"other","Lafayette: Macon County Confederate Monument (2001)",2001
+"other","Richardson, William D.; McNinch-Su, Ron (2001). Martinez, J. Michael (ed.). Confederate Symbols in the Contemporary South. University Press of Florida. ISBN 978-0813021003.",2001
+"other","Stephenville: Confederate Soldiers' Monument (2001), Erath County Courthouse[505]",2001
+"other","Alachua: Confederate monument, Newnansville Cemetery (2002) by the Alachua Lions Club[194]",2002
+"other","Blight, David W. (2002). Beyond the Battlefield: Race, Memory, and the American Civil War. University of Massachusetts Press. ISBN 978-1558493612.",2002
+"other","Blight, David W. (2002). Race and Reunion: The Civil War in American Memory. Belknap Press. ISBN 978-0674008199.",2002
+"other","Comanche: Confederate Soldiers' Monument (2002), Comanche County Courthouse[463]",2002
+"other","Freeman's Battery (2002)",2002
+"other","White Springs: Confederate monument and large flag, along Interstate 75 (2002)[203]",2002
+"other","Cox, Karen L. (2003). Dixie's Daughters: The United Daughters of the Confederacy and the Preservation of Confederate Culture. University Press of Florida. ISBN 978-0813028125.",2003
+"other","Fox's Gap, Frederick County, Maryland: North Carolina Monument (2003):  The monument is a life sized bronze figure of a wounded Confederate color bearer on a base of black granite. It was created by sculptor Gary Casteel for the Living History association of Mecklinburg, North Carolina, and unveiled on October 18, 2003. It is dedicated to all the North Carolina troops who fought in the Battle of South Mountain.  Fox's Gap is the southernmost battlefield of the Battle of South Mountain.  The property is owned by the Central Maryland Heritage League, a battlefield protection group.[321]",2003
+"other","North Carolina Memorial at Fox's Gap (2003)",2003
+"other","Robert E. Lee Statue at Antietam Creek, Antietam National Battlefield (2003)[316] The statue is attempting to be removed by legislation through H.R.970 (2019)[317] and the National Park Service acknowledges the inaccuracies of the statue and educates those in the park accordingly.",2003
+"other","Rock Island: UDC obelisk (2003), Rock Island Confederate Cemetery. Dedicated to Confederate soldiers who died at Rock Island Military Prison[241]",2003
+"other","SCV Memorial to Confederate soldiers (2003), Confederate Cemetery, adjoining the City Cemetery""[399]",2003
+"other","Waynesboro: Confederate Monument (2003)",2003
+"other","Brown, Thomas J. (2004). The Public Art of Civil War Commemoration: A Brief History with Documents. Bedford/St. Martin's. ISBN 978-0312397913.",2004
+"other","Cookeville: Confederate Memorial, Cookeville Cemetery (2004)[399]",2004
+"other","Dyersburg: Confederate monument (2004), Old City Cemetery[399]",2004
+"other","McMinnville: Warren County Civil War Memorial (2004)[399]",2004
+"other","Wynnewood: Confederate Soldier monument (2004)[385]",2004
+"other","Bloomfield:[256] Confederate Invasion of Iowa Monument (2005)[257]",2005
+"other","Neff, John R. (2005). Honoring the Civil War Dead: Commemoration and the Problem of Reconciliation. University Press of Kansas. ISBN 978-0700613663.",2005
+"other","Springfield: UDC/SCV monument (2005), Camp Butler National Cemetery. Dedicated to Confederate soldiers who died at Camp Butler.[242]",2005
+"other","Hardy, Michael C. (2006). Remembering North Carolina's Confederates. Arcadia. ISBN 978-0738542973.",2006
+"other","Obion: Obion Veterans Memorial, honoring those who were killed in service and were MIA-POW in Civil War, World Wars I & II, Korea, Vietnam, Desert Storm, Afghanistan and Iraq (2006)[399]",2006
+"other","St. Cloud: Confederate monument, Veterans Park (2006)[190]",2006
+"other","Bentonsport: Monument to Lawrence Sullivan Ross (2007), Iowa's only Confederate general[256]",2007
+"other","Clark County: Near Ridgefield is Jefferson Davis Park (2007), established by the SCV to hold the Jeff Davis Highway markers from Blaine and Vancouver. Flags of the Confederacy are also displayed there.[551][552]",2007
+"other","Morton's Battery (2007)",2007
+"other","Perry: Confederate monument, Taylor County Sports Complex (2007)[184][185]",2007
+"other","Memorial to the 20th Tennessee Volunteer Infantry (2008), in Beechgrove Confederate Cemetery.[399]",2008
+"other","Benton: Confederate memorial (2009)[399]",2009
+"other","Johnson, Kristina Dunn (2009). No Holier Spot of Ground: Confederate Monuments & Cemeteries of South Carolina. The History Press. ISBN 978-1596293977.",2009
+"other","Waverly: CSA Gen. Joseph O. Shelby Statue (2009).",2009
+"other","Wilson, Charles (2009). Baptized in Blood: The Religion of the Lost Cause, 1865–1920 (2nd ed.). University of Georgia Press. ISBN 978-0820334257.",2009
+"other","Anderson: Confederate Memorial Plaza (2010).[512] The plaza beside the Grimes County courthouse flies a Confederate flag behind a gate with metal lettering reading ""Confederate Memorial Plaza."" A metal statue depicts one of several Grimes County residents who fought with the 4th Texas volunteer infantry brigade in Virginia.[447]",2010
+"other","Dade City: Confederate memorial, Townsend House Cemetery (2010)[197]",2010
+"other","Quincy: Confederate memorial, Soldiers Cemetery within Eastern Cemetery, part of the town's National Register Historic District (2010). The memorial also notes the restoration of the historic fence.[186][187]",2010
+"other","Trenton: Confederate monument, across from Gilchrist County Courthouse in Veterans' Park (2010)[192]",2010
+"other","Rutherford County Confederate Veterans Memorial (2011)",2011
+"other","Confederate Veterans Memorial (2012) ""honoring gallant soldiers, veterans and their families.""[399]",2012
+"other","Socorro: Confederate monument (2012) entitled Victory Awaits You[358]",2012
+"other","Trimble: Cemetery Ridge Memorial Plaza, honoring Merion Spence Parks and Williams Hamilton Parks II, members of UDC and SCV respectively (2012)[399]",2012
+"other","Confederate Monument (2013) at Rose Hill Cemetery[380]",2013
+"other","Culp Brothers Memorial (2013), Gary Casteel, sculptor, near entrance Gettysburg Heritage Center. Honors brothers who fought on opposite sides: Confederate Private Wesley Culp and Union Lieutenant William Culp (""Brother against Brother"").[389]",2013
+"other","Palestine: Confederate Veterans Memorial Plaza (2013), funded by the Sons of the Confederate Veterans[525]",2013
+"other","USNS Maury (T-AGS-66) (2013), named for Matthew Fontaine Maury, was renamed USNS Marie Tharp for oceanographer Marie Tharp in 2023.[95]",2013
+"other","Hagler, Gould B. Jr. (2014). Georgia's Confederate Monuments: In Honor of a Fallen Nation. Mercer University Press. ISBN 978-0881464665.",2014
+"other","Lees, William B.; Gaske, Frederick P. (2014). Recalling Deeds Immortal: Florida Monuments to the Civil War. University Press of Florida. ISBN 978-0813049960.",2014
+"other","Brown, Thomas J. (2015). Civil War Canon: Sites of Confederate Memory in South Carolina. University of North Carolina Press. ISBN 978-1469620954.",2015
+"other","Cleburne: Cleburne Monument (2015) Confederate Arch (1922)",2015
+"other","As of 24 June 2020[update], there are at least 105 public spaces with Confederate monuments in Tennessee. The Tennessee Heritage Protection Act (2016) and a 2013 law restrict the removal of statues and memorials.[43]",2016
+"other","Brandenburg: Confederate monument (2016) removed from Louisville[258] Armed protesters surrounded the monument to prevent its removal in June 2020.[259]",2016
+"other","Janney, Caroline E. (2016). Remembering the Civil War: Reunion and the Limits of Reconciliation. University of North Carolina Press. ISBN 978-1469629896.",2016
+"other","Hood's Texas Brigade, a monument ""to memorialize those [who] fought for the Confederacy"".[448] ""The monument includes a depiction of a Confederate soldier, quotes by Confederate leaders, a flag of the Confederacy and the Confederate battle flag.""[449] These are the only Confederate flags currently (2017) visible in the Capitol.[450] Representative Eric Johnson has called for its removal.[449]",2017
+"other","Johnston High School: Named for Albert Sidney Johnston, Confederate general killed in the Battle of Shiloh. The school closed in 2008; Eastside Memorial High School is now (2017) at that location.[535]",2017
+"other","Moltke-Hansen, David (2017). ""Honoring the Confederate Defeat the Georgia Way"". Georgia Historical Quarterly. Vol. 101, no. 1. pp. 1–23.",2017
+"other","Robert E. Lee Statue at Antietam Creek, Antietam National Battlefield (2003)[316] The statue is attempting to be removed by legislation through H.R.970 (2019)[317] and the National Park Service acknowledges the inaccuracies of the statue and educates those in the park accordingly.",2019
+"south_carolina","Hampton County (1878)",1878
+"south_carolina","In August 2017, ""a coalition of Columbia-area groups is calling for the S.C. Legislature to remove several monuments on the State House grounds.""[3]South Carolina's Confederate Dead (1879), also known as the South Carolina Soldiers Monument.[4] It was unveiled before a crowd of 15,000.[5] The monument was largely destroyed by lightning in 1882, but was replaced by the state two years later.[5] It is positioned on the northern end of the State House grounds. After a decision by the Legislature to remove the Confederate flag from the dome of the State House, where it had flown since 1962, the monument flew a traditional version of the Confederate Battle Flag from 2000 to 2015; the flag was the subject of protests and national level political debate.[6][7] In 2015 it was removed by a 2/3 vote of both houses of the Legislature.[8] It is displayed in the South Carolina Confederate Relic Room & Military Museum.",1879
+"south_carolina","Darlington: Monument to the Confederate Dead (1880)",1880
+"south_carolina","Newberry Confederate Monument (1880)",1880
+"south_carolina","Confederate War Memorial (1883)[1]",1883
+"south_carolina","Lexington: Lexington Confederate Monument (1886)",1886
+"south_carolina","City of Kershaw (1888)",1888
+"south_carolina","Defenders of State Sovereignty Monument (1891)",1891
+"south_carolina","Greenville: Confederate Monument (1892)",1892
+"south_carolina","Confederate Monument (1893)",1893
+"south_carolina","Loyal slaves monument (1896). Local cotton mill owner Samuel E. White and the Jefferson Davis Memorial Association dedicated the memorial to honor the ""faithful slaves who loyal to a sacred trust toiled for the support of the army with matchless devotion and sterling fidelity guarded our defenceless homes, women and children during the struggle for the principles of our Confederate States of America.""[22] ""Two opposing sides of the 13-foot-tall marble monument feature bas-relief carvings depicting enslaved blacks, including a 'mammy' figure cradling a white baby and a black man cutting wheat."" The main speaker at the dedication was Polk Miller, a white defender of slavery, who in his remarks ""pitted what he called the 'uppity,' turn-of-the-century African American against the 'negro of the good old days gone-by,' suggesting emancipation had been an unfortunate development.""[23]  This monument is seen as an example of the Lost Cause of the Confederacy movement.[23] See also Heyward Shepherd monument.",1896
+"south_carolina","Bamberg County (1897)",1897
+"south_carolina","Catawba Indian Monument (1900)",1900
+"south_carolina","Edgefield Confederate Monument (1900)",1900
+"south_carolina","Aiken: Confederate Memorial (1901)[1]",1901
+"south_carolina","Monument to Henry Timrod (1901), ""author of poetic paeans to the Confederacy"": ""Sleep martyrs, of a fallen cause."".[20]",1901
+"south_carolina","Winnsboro: Confederate Memorial (1901)",1901
+"south_carolina","Lee County (1902)",1902
+"south_carolina","Greenwood: Confederate Monument (1903)[14]",1903
+"south_carolina","Marion: Marion Monument ""To the Dead and Living Confederate Veterans"" (1903)",1903
+"south_carolina","Statue of General Pierre Beauregard (1904).",1904
+"south_carolina","Abbeville Confederate Monument (1906)[16]",1906
+"south_carolina","Wade Hampton III Confederate Monument (1906),[1] 16-foot bronze equestrian statue, also by Frederick Ruckstull. There is also a statue of him within the Capitol.[9]",1906
+"south_carolina","York: York County Confederate Monument (1906)",1906
+"south_carolina","Bennettsville: Confederate Monument (1907)[1]",1907
+"south_carolina","Jonesville: Confederate Monument (1907)",1907
+"south_carolina","Cross Hill: Confederate Monument (1908)",1908
+"south_carolina","Rock Hill: Ebenezer Confederate Monument (1908)",1908
+"south_carolina","Lancaster: Our Confederate Soldiers Monument (1909)",1909
+"south_carolina","Kingstree: Confederate Soldier, Williamsburg County Monument (1910)",1910
+"south_carolina","Laurens Confederate Monument (1910)",1910
+"south_carolina","Spartanburg: Confederate Soldier Monument (1910)",1910
+"south_carolina","Walhalla: ""Our Confederate Dead"" Monument (1910)",1910
+"south_carolina","Richard Kirkland Memorial Fountain (1911)[1]",1911
+"south_carolina","Walterboro: Confederate Monument (1911)",1911
+"south_carolina","Monument to the South Carolina Women of the Confederacy (1912),[1] a bronze monument by Frederic W. Ruckstull.[4]",1912
+"south_carolina","Bishopville: Lee County Monument to the Confederate Dead at Lee County Courthouse (1913)[13]",1913
+"south_carolina","Manning: Confederate Monument (1914)",1914
+"south_carolina","St. Matthews: ""Lest We Forget"" Monument (1914)",1914
+"south_carolina","Union: Union County Confederate Memorial (1917)",1917
+"south_carolina","Gaffney: Cherokee County Confederate Monument (1922)[24]",1922
+"south_carolina","First Secession Meeting Columns Monument (1927)[1]",1927
+"south_carolina","Prosperity: Confederate Veterans Monument (1928)",1928
+"south_carolina","Georgetown: Confederate Monument (1929) at Battery White[25]",1929
+"south_carolina","Seneca: UDC Memorial Gateway (1933) dedicated to Confederate soldiers at entrance to Mountain View Cemetery[26]",1933
+"south_carolina","Williamston: Confederate Monument (1942)",1942
+"south_carolina","Westminster Confederate Monument (1980)",1980
+"south_carolina","The state restricted the removal of memorials and statues with the South Carolina Heritage Act (2000), which states that ""no historical monument can be altered or moved without a two-thirds vote in both chambers of the state's General Assembly"".[2]",2000
+"south_carolina","Confederate Flag and Monument (2001)",2001
+"south_carolina","Salem Confederate Monument (2004)",2004
+"south_carolina","Moncks Corner: Berkeley County Confederate Monument (2011)",2011
+"virginia","Plaques (1870) of Robert E. Lee and George Washington hang on either side of the altar at Christ Church, where both were parishioners.  Following a unanimous vote of its board in 2017, the church announced the plaques would be removed in 2018 once a new location of ""respectful prominence"" is identified.[14][15][16]Robert E. Lee hitched his horse in Berryville, Virginia, while on his march to Gettysburg",1870
+"virginia","Grave of Traveller, Robert E. Lee's horse (1871). Apples are regularly placed on the grave by visitors.[30]",1871
+"virginia","Lancaster: Lancaster County Confederate Monument (1872)",1872
+"virginia","Heathsville: Civil War Memorial, Northumberland County (1873)",1873
+"virginia","Montross: Westmoreland County Confederate Monument (1876)",1876
+"virginia","Confederate Dead Monument (1877).[12] Updated in 1998 with aid from the United Daughters of the Confederacy and local businesses.[13]",1877
+"virginia","General Thomas J. Jackson Shaft (1888), ""On this spot fell mortally wounded Thomas J. Jackson Lt. Gen. C.S.A. May 2nd 1863""[20]",1888
+"virginia","Glen Allen: J.E.B. Stuart Memorial (1888)",1888
+"virginia","Jackson Memorial Boulder and Tablet (1888), placed by former members of Stonewall Jackson's staff[19]",1888
+"virginia","Thomas R.R. Cobb Monument and Marker (1888)",1888
+"virginia","Gloucester: Confederate Monument (1889)",1889
+"virginia","Suffolk: Confederate Monument (1889), Cedar Hill Cemetery[38]",1889
+"virginia","Nottoway: Confederate Monument (1893)",1893
+"virginia","University of Virginia Cemetery: Confederate monument (1893), by Caspar Buberl.[9] Justin Greenlee draws a parallel between the erection of this monument, at whose dedication slavery was denied as a cause of the Civil War, and the adjacent cemetery for slaves, which was robbed of bodies for dissection in UVA's School of Medicine and Anatomy.[21]",1893
+"virginia","Confederate Soldiers and Sailors Monument, Libby Hill Park (1894). Defaced with graffiti in 2015.[37]",1894
+"virginia","Strasburg: Confederate Monument (1896), Strasburg Presbyterian Church Cemetery[20]",1896
+"virginia","Confederate Monument (1898)",1898
+"virginia","Harrisonburg: Turner Ashby Monument (1898), located on Turner Ashby Lane.[40] In 2019, the monument was vandalized ""when someone threw eggs, raw meat, and other substances on it."" In February, 2020, it was vandalized with red paint.[41]",1898
+"virginia","Washington: Confederate Monument (1898)",1898
+"virginia","Gloucester: Confederate Monument (1899)",1899
+"virginia","Parksley: Confederate Monument (1899). Inscriptions read: ""They died for the principles upon which all true republics are founded""; ""They fought for conscience sake [ sic ] and died for right""; ""At the call of patriotism and duty, they encountered the perils of the field and were faithful even unto death."" The front of the monument gives this information: ""Erected by Harmanson-West Camp Confederate Volunteers in memory of their dead comrades from Accomack and Northampton Counties."" The monument was made by Gaddess Brothers of Baltimore of Barre granite, and is about 30 feet tall.[8]",1899
+"virginia","Berryville: Confederate Memorial (1900)",1900
+"virginia","Confederate Monument on Monument Terrace (1900)",1900
+"virginia","Charlotte: Charlotte County Confederate Memorial (1901)",1901
+"virginia","King William: To Our Soldiers of the Confederacy Monument (1901)",1901
+"virginia","Palmyra: Confederate Memorial (1901)",1901
+"virginia","Buchanan: Botetourt Artillery Obelisk (1902)[9]",1902
+"virginia","""Lee to the Rear!"" Tablet (1903), ""Lee to the Rear! Cried the Texans. May 6, 1864""[20]",1903
+"virginia","'Lee's Headquarters' monument (1903)[52]",1903
+"virginia","Chesterfield: Confederate Memorial (1903)",1903
+"virginia","Lee-Jackson Bivouac Shaft (1903), ""Bivouac, Lee and Jackson, night of May 1, 1863""[20]",1903
+"virginia","Monument near where Stonewall Jackson's arm was buried, Wilderness, VirginiaWilderness: Monument (1903) near where Stonewall Jackson's amputated arm was buried[20]",1903
+"virginia","Mount Jackson: ""Our Soldiers Cemetery"" statue (1903)",1903
+"virginia","Surry: Confederate Monument (1903)",1903
+"virginia","Tazewell: Confederate Memorial (1903)",1903
+"virginia","Fincastle: Confederate Memorial (1904)[9]",1904
+"virginia","Floyd: Confederate Monument (1904)",1904
+"virginia","Marion: Confederate Monument (1904)",1904
+"virginia","Amelia: Confederate Monument (1905)",1905
+"virginia","Appomattox: Confederate Monument (1905)",1905
+"virginia","Courtland: Confederate Monument (1905)",1905
+"virginia","Louisa: Confederate Monument (1905)",1905
+"virginia","Smithfield: Confederate Monument (1905)",1905
+"virginia","Two monuments at Big Bethel Cemetery, within Langley Air Force Base:[25]Big Bethel UDC Monument (1905)[26]",1905
+"virginia","Virginia Beach: Princess Anne County Confederate Heroes Monument (1905)",1905
+"virginia","Windsor: Confederate Monument (1905)",1905
+"virginia","Pulaski: In Memory of the Confederate Soldiers of Pulaski County, 1861–1865 Monument (1906)",1906
+"virginia","Abingdon: Confederate Monument (1907), Frederick William Sievers, sculptor[6]",1907
+"virginia","Hillsville: Confederate Monument (1907)",1907
+"virginia","Buckingham: Confederate Soldiers of Buckingham County (1908)",1908
+"virginia","Buckingham: Monument and cannon dedicated to the Confederate soldiers of Buckingham County. (1908)[7]",1908
+"virginia","Williamsburg: Williamsburg Confederate Monument (1908)",1908
+"virginia","Dinwiddie: Confederate Monument (1909)",1909
+"virginia","New Market: This Rustic Pile Monument (1909)",1909
+"virginia","Newport News: Confederate Soldier Monument (1909)",1909
+"virginia","Old Men and Boys Monument (1909), in Petersburg National Battlefield. Text: ""This stone marks the spot where the old men and boys of Petersburg under Gen. R.E. Colston and Col. F.H. Archer 125 strong on June 9th, 1864 distinguished themselves in a fight with 1,300 Federal Cavalry under Gen. Kautz, gaining time for the defeat of the expedition. // Placed by the Petersburg Chapter U.D.C. May 1909""",1909
+"virginia","Tappahannock: Essex County Confederate Monument (1909)",1909
+"virginia","Bristol: Confederate Soldier Monument (1910)[9]",1910
+"virginia","Emporia: Confederate Memorial (1910)",1910
+"virginia","Lawrenceville: Brunswick County Confederate Monument (1910)",1910
+"virginia","Rocky Mount: Confederate Monument (1910)",1910
+"virginia","Bland: Confederate Monument (1911)",1911
+"virginia","Franklin: Confederate Monument (1911)",1911
+"virginia","Front Royal: Confederate Monument (1911)",1911
+"virginia","Halifax: Confederate Memorial (1911)",1911
+"virginia","Colonel James D. Nance Tablet (1912), marks where Nance was killed[20]",1912
+"virginia","Mathews: Our Confederate Soldier Monument (1912)",1912
+"virginia","New Castle: Confederate Monument (1912)",1912
+"virginia","Sussex: Confederate Monument (1912)",1912
+"virginia","Eastville: Confederate Monument (1913). ""Erected by Harmanson-West camp Confederate veterans, the daughters of the Confederacy, and the citizens of the Eastern Shore of Virginia to the soldiers of the Confederacy from Northampton and Accomack Counties. They died bravely in war, or, in peace live nobly to rehabilitate their country. A. D. 1913.""[8]",1913
+"virginia","Hanover: Confederate Monument (1914)",1914
+"virginia","Harrisonburg, Virginia: ""Talbot Boys"" monument (1914) at the Cross Keys battlefield, moved there from Talbot County Courthouse, Maryland, in 2022.[29]",1914
+"virginia","Lebanon: Confederate Monument (1914)",1914
+"virginia","Lunenburgh: Confederate Monument (1916)",1916
+"virginia","Monument to CSA colonel John S. Mosby (1916)[11]",1916
+"virginia","Winchester: Confederate Soldiers Monument (1916) – in front of former courthouse, now museum. Plaque reads: ""In honor of the Confederate soldiers from Winchester and Frederick County who faithfully served the South.""",1916
+"virginia","Monterey: Confederate Monument (1918)",1918
+"virginia","Page County Confederate Monument (1918)",1918
+"virginia","Spotsylvania Courthouse: Confederate Monument (1918)",1918
+"virginia","Fort Early and Jubal Early Monument (1919)",1919
+"virginia","Middletown: Monument (1919) to Stephen Dodson Ramseur at entrance to Belle Grove Plantation, where he died following the Battle of Belle Grove.[34]",1919
+"virginia","Stephenson: Memorial to Lieutenant Colonel Richard Snowden Andrews and Men of 1st Maryland Battery, CSA (1920)",1920
+"virginia","Amherst: Amherst County Confederate Monument (1922)",1922
+"virginia","Warm Springs: Confederate Memorial (1922)",1922
+"virginia","Goshen Pass: Maury Memorial, stone monument marker (1923)",1923
+"virginia","Mahone Monument, Battle of the Crater, Petersburg National Battlefield (1927), erected by the United Daughters of the Confederacy",1927
+"virginia","Wilderness Battlefield Tablet (1927), UDC monument[20]",1927
+"virginia","Culpeper County: UDC monument (1929) commemorating Confederate victory in the Battle of Brandy Station[22]",1929
+"virginia","Francis H. Smith statue (1931). Smith served in the CSA for four years during his tenure at VMI.[1][32]",1931
+"virginia","New Kent: Confederate Monument (1934)",1934
+"virginia","Bedford: Confederate Memorial (1935)",1935
+"virginia","Lee-Jackson Bivouac Tablet (1937)[20]",1937
+"virginia","Stuart: Stuart Elementary School (1938)",1938
+"virginia","Stonewall Jackson Elementary School (1948)",1948
+"virginia","Hopewell: Confederate Memorial (1949)",1949
+"virginia","Fredericksburg: Lee Hill Elementary School (1952)[1]",1952
+"virginia","Texas Brigade Shaft (1964), ""'Who are you my boys?' Lee cried as he saw them gathering. 'Texas boys,' they yelled, their number multiplying each second.""[20]",1964
+"virginia","UDC Monument (1964), commemorating the 100th anniversary of the Battle of Big Bethel[27]",1964
+"virginia","""The Angel of Marye's Heights"" Monument, statue of Sergeant Richard Rowland Kirkland giving water to fallen union soldier. (1965)[23][24]",1965
+"virginia","Lovingston: Confederate Monument (1965)",1965
+"virginia","Washington-Lee Elementary School (1968)",1968
+"virginia","Brigadier General Elisha F. Paxton Tablet (1980), ""In this vicinity Brig. Gen. E. F. Paxton, C.S.A. Aged 35 years, of Rockbridge County, VA. was killed on the morning of May 3, 1863 while leading his command, the Stonewall Brigade in the attack on Fairview""[20]",1980
+"virginia","Berryville: Memorial (1986) and ""hitching post"" where Robert E. Lee tethered his horse, Traveller, while Lee ""paused on his march to Gettysburg"" to attended a church service[17]",1986
+"virginia","Lees Corner Elementary, named for Lee family (including Robert E. Lee) as owners of Sully Plantation (1986)[49]",1986
+"virginia","Gate City: Confederate Memorial (1988)",1988
+"virginia","Pearisburg: Confederate Medal of Honor Monument (1995). Inscribed is the Jefferson Davis quote, ""It is a duty we owe to posterity to see that our children shall know the virtues and rise worthy of their sires.""[10]",1995
+"virginia","Brandy Station: UDC monument (1998) dedicated to John Pelham[18]",1998
+"virginia","Mechanicsville: Wilcox's Alabama Brigade (1999)",1999
+"virginia","Powhatan: Powhatan Troop Confederate Memorial (1999)",1999
+"virginia","Nickelsville: Nickelsville Spartan Band Monument (2000)",2000
+"virginia","Ramseur's Brigade monument (2001)[53]",2001
+"virginia","Confederate Monument (2009)",2009
+"virginia","The Heights at Smith Run (2014)",2014


### PR DESCRIPTION
## Summary

- Add a local snapshot of the Confederate statue dates CSV under `data/`.
- Update `confederate_statues.Rmd` to read the local snapshot instead of downloading from GitHub Raw during site renders.
- Add a monthly/manual cache refresh workflow that validates the upstream CSV, commits cache changes directly to `main`, and dispatches the site build after a successful update.

## Why

The site sanity workflow failed when `readr::read_csv()` could not open the GitHub Raw CSV URL while rendering `confederate_statues.Rmd`. The source URL was available again afterward, so this appears to have been a transient network/read failure. Reading a committed data snapshot removes that external dependency from the render path.

The updater keeps the snapshot current while still constraining the scheduled write to `data/confederate_statue_dates.csv` only.

## Validation

- Restored the local R package environment with `renv::restore(prompt = FALSE)`.
- Ran an R-level check that loads `data/confederate_statue_dates.csv`, verifies the expected row count and columns, and confirms the existing max-year calculation returns 1910 with 47 entries.
- Ran the updater workflow's fetch-and-validate shell/Python logic locally against the upstream CSV; it validated 970 rows.
- Attempted a focused `rmarkdown::render("confederate_statues.Rmd")`; the R chunks completed, but Pandoc failed afterward on an existing local standalone render path issue for `/header/apple-touch-icon.png`.