### PR TITLE
Dual-license: MIT for code, CC BY 4.0 for content

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,6 +2,7 @@ Package: site
 Title: Personal Site
 Version: 0.0.1
 Description: R Markdown site for cavandonohoe.github.io
+License: MIT + file LICENSE | CC-BY-4.0 (content, see LICENSE-CONTENT.md)
 Depends: R (>= 4.2)
 Imports:
     rmarkdown,

--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,8 @@
+This repository is dual-licensed. The source code is licensed under the MIT
+License (below). The written content (prose, articles, images, and the CV) is
+licensed under Creative Commons Attribution 4.0 International (CC BY 4.0); see
+LICENSE-CONTENT.md. See the "License" section of the README for details.
+
 MIT License
 
 Copyright (c) 2025 Cavan Donohoe

--- a/LICENSE-CONTENT.md
+++ b/LICENSE-CONTENT.md
@@ -1,0 +1,35 @@
+# Content License
+
+The **written content** of this repository (prose, articles, page copy,
+images, and the CV) is licensed under the
+[Creative Commons Attribution 4.0 International License (CC BY 4.0)](https://creativecommons.org/licenses/by/4.0/).
+
+Copyright (c) 2025 Cavan Donohoe
+
+## What this covers
+
+- Article and blog text in the `*.Rmd` pages (the written narrative, not the code)
+- Images under `images/`
+- The CV content (`cv.Rmd`, `cv_doc.Rmd`, and the generated `cv.pdf` / `cv_doc.docx`)
+
+The **source code** (R, R Markdown chunks, scripts, workflows, and configuration)
+is licensed separately under the MIT License; see [LICENSE](LICENSE).
+
+## You are free to
+
+- **Share** — copy and redistribute the material in any medium or format
+- **Adapt** — remix, transform, and build upon the material for any purpose,
+  even commercially
+
+## Under the following terms
+
+- **Attribution** — You must give appropriate credit, provide a link to the
+  license, and indicate if changes were made. You may do so in any reasonable
+  manner, but not in any way that suggests the licensor endorses you or your use.
+
+No warranties are given. The license may not give you all of the permissions
+necessary for your intended use. For example, other rights such as publicity,
+privacy, or moral rights may limit how you use the material.
+
+The full legal text is available at
+<https://creativecommons.org/licenses/by/4.0/legalcode>.

--- a/README.Rmd
+++ b/README.Rmd
@@ -343,3 +343,13 @@ Local development, prerequisites, build steps, lint/test commands, and PR conven
 ### Deployment
 
 The site is automatically deployed to GitHub Pages via GitHub Actions when changes are pushed to the `main` branch. See the Automation section above for the full list of workflows.
+
+## License
+
+This repository is dual-licensed to cover both its code and its written content:
+
+- **Code** (R, R Markdown chunks, scripts, workflows, and configuration) is licensed under the [MIT License](LICENSE).
+- **Content** (prose, articles, images, and the CV) is licensed under [Creative Commons Attribution 4.0 International (CC BY 4.0)](LICENSE-CONTENT.md).
+
+In short: reuse the code freely with attribution and no warranty, and share or adapt the writing and images as long as you give credit.
+

--- a/README.md
+++ b/README.md
@@ -153,3 +153,17 @@ PR conventions all live in [CONTRIBUTING.md](CONTRIBUTING.md).
 The site is automatically deployed to GitHub Pages via GitHub Actions
 when changes are pushed to the `main` branch. See the Automation section
 above for the full list of workflows.
+
+## License
+
+This repository is dual-licensed to cover both its code and its written
+content:
+
+- **Code** (R, R Markdown chunks, scripts, workflows, and configuration)
+  is licensed under the [MIT License](LICENSE).
+- **Content** (prose, articles, images, and the CV) is licensed under
+  [Creative Commons Attribution 4.0 International (CC BY
+  4.0)](LICENSE-CONTENT.md).
+
+In short: reuse the code freely with attribution and no warranty, and
+share or adapt the writing and images as long as you give credit.


### PR DESCRIPTION
## Summary

The repo is a mix of source code and written content (article prose, images, CV), but it was only covered by the MIT license, which really only fits the code. This adds a Creative Commons Attribution 4.0 license for the content so the writing and images are properly covered too.

- **Code** stays MIT (`LICENSE`).
- **Content** (prose, images, CV) is now CC BY 4.0 (`LICENSE-CONTENT.md`).
- Added a note at the top of the MIT `LICENSE` explaining the split.
- Documented both in a new README "License" section (edited both `README.Rmd` source and generated `README.md`).
- Declared the licenses in `DESCRIPTION`.

## Test plan

- [ ] Confirm GitHub detects the MIT license in the repo sidebar.
- [ ] Confirm the README License section renders with working links to both license files.