### PR TITLE
Make CC BY 4.0 content license detectable

### DIFF
--- a/LICENSE-CONTENT.md
+++ b/LICENSE-CONTENT.md
@@ -1,12 +1,5 @@
 Creative Commons Attribution 4.0 International
 
-The written content of this repository (prose, articles, page copy, images,
-and the CV) is licensed under CC BY 4.0. The source code is licensed
-separately under the MIT License; see LICENSE. See the README "License"
-section for the scope of each license.
-
-Copyright (c) 2025 Cavan Donohoe
-
 =======================================================================
 
 Creative Commons Corporation ("Creative Commons") is not a law firm and


### PR DESCRIPTION
## Summary

After #128, the repo sidebar correctly shows MIT, but `LICENSE-CONTENT.md` still reads as "Unknown". GitHub's license matcher (Licensee) strips a single leading title/copyright block, but the file had an extra scope note plus a copyright line wedged between the title and the canonical legal text, which broke the template match.

This removes the injected preamble so the file is the verbatim CC BY 4.0 legal code. The scope of the content license (what it covers vs. the code) is already documented in the README License section and in the note at the top of the MIT `LICENSE`, so nothing is lost.

## Test plan

- [ ] After merge and reindex, confirm the "Licenses found" popover recognizes CC BY 4.0 for `LICENSE-CONTENT.md` instead of "Unknown".