### PR TITLE
Add Schitt's Creek ratings plot

### DIFF
--- a/data/schitts_creek_ep_ratings.csv
+++ b/data/schitts_creek_ep_ratings.csv
@@ -1,0 +1,81 @@
+season,episode,title,rating,votes
+1,1,Our Cup Runneth Over,7,3447
+1,2,The Drip,7.2,2880
+1,3,"Don't Worry, It's His Sister",7.5,2711
+1,4,Bad Parents,7.4,2496
+1,5,The Cabin,7.8,2494
+1,6,Wine and Roses,7.5,2414
+1,7,Turkey Shoot,7.5,2302
+1,8,Allez-Vous,7.2,2223
+1,9,Carl's Funeral,7.5,2224
+1,10,Honeymoon,7.9,2273
+1,11,Little Sister,7.3,2148
+1,12,Surprise Party,7.8,2126
+1,13,Town for Sale,7.9,2160
+2,1,Finding David,7.7,2117
+2,2,Family Dinner,7.8,2052
+2,3,Jazzagals,7.4,1932
+2,4,Estate Sale,7.6,1899
+2,5,Bob's Bagels,7.8,1912
+2,6,Moira vs. Town Council,7.6,1871
+2,7,The Candidate,7.5,1813
+2,8,Milk Money,8,1876
+2,9,Moira's Nudes,8.1,1893
+2,10,Ronnie's Party,7.6,1781
+2,11,The Motel Guest,7.7,1794
+2,12,Lawn Signs,7.9,1827
+2,13,Happy Anniversary,8.9,2835
+3,1,Opening Night,7.7,1867
+3,2,The Throuple,7.8,1807
+3,3,New Car,8.1,1865
+3,4,Driving Test,7.7,1749
+3,5,Rooms by the Hour,7.8,1763
+3,6,Murder Mystery,7.5,1718
+3,7,General Store,7.6,1722
+3,8,Motel Review,7.9,1756
+3,9,The Affair,8.1,1738
+3,10,Sebastien Raine,7.4,1693
+3,11,Stop Saying Lice!,8,1743
+3,12,Friends & Family,8.4,1814
+3,13,Grad Night,8.9,2313
+4,1,Dead Guy in Room 4,7.8,1764
+4,2,Pregnancy Test,8,1734
+4,3,Asbestos Fest,7.4,1645
+4,4,Girls' Night,7.7,1669
+4,5,RIP Moira Rose,8.1,1705
+4,6,Open Mic,8.8,2625
+4,7,The Barbecue,8.2,1727
+4,8,The Jazzaguy,8,1641
+4,9,The Olive Branch,8.5,2190
+4,10,Baby Sprinkle,7.7,1640
+4,11,The Rollout,8,1608
+4,12,Singles Week,9,2353
+4,13,"Merry Christmas, Johnny Rose",8.6,1847
+5,1,The Crowening,7.9,1739
+5,2,Love Letters,7.8,1604
+5,3,The Plant,7.9,1578
+5,4,The Dress,7.7,1548
+5,5,Housewarming,8.3,1749
+5,6,Rock On!,7.7,1556
+5,7,A Whisper of Desire,7.7,1535
+5,8,The Hospies,8.1,1626
+5,9,The M.V.P.,8.2,1667
+5,10,Roadkill,7.4,1605
+5,11,Meet the Parents,9.1,2480
+5,12,The Roast,8,1536
+5,13,The Hike,8.9,2043
+5,14,Life Is a Cabaret,9.1,2271
+6,1,Smoke Signals,8,1642
+6,2,The Incident,8.2,1641
+6,3,The Job Interview,7.7,1501
+6,4,Maid of Honour,7.7,1481
+6,5,The Premiere,8.3,1571
+6,6,The Wingman,7.6,1501
+6,7,Moira Rosé,8.3,1614
+6,8,The Presidential Suite,8.5,1721
+6,9,Rebound,7.8,1467
+6,10,"Sunrise, Sunset",8.1,1498
+6,11,The Bachelor Party,8.3,1553
+6,12,The Pitch,8.7,1676
+6,13,Start Spreading the News,9.2,2241
+6,14,Happy Ending,9.3,2977

--- a/imdb_rating_plot.Rmd
+++ b/imdb_rating_plot.Rmd
@@ -170,6 +170,16 @@ the_office %>%
   interactive_plotly
 ```
 
+## Schitt's Creek
+
+```{r}
+schitts_creek <- readr::read_csv(here::here("data", "schitts_creek_ep_ratings.csv"))
+
+schitts_creek %>%
+  create_episode_plot("Schitt's Creek") %>%
+  interactive_plotly
+```
+
 ## How I Met Your Mother
 
 ```{r}

--- a/web_scraping/imdb_season_episode_ratings_plot.R
+++ b/web_scraping/imdb_season_episode_ratings_plot.R
@@ -334,6 +334,7 @@ shows <- tibble::tribble(
   "brooklyn nine-nine", "tt2467372",   "brooklyn_nine_nine",
   "avatar",             "tt0417299",   "avatar",
   "the office us",      "tt0386676",   "the_office",
+  "schitt's creek",     "tt3526078",   "schitts_creek",
   "death note",         "tt0877057",   "death_note",
   "andor",              "tt9253284",   "andor",
   "modern love",        "tt8543390",   "modern_love",


### PR DESCRIPTION
## Summary

Adds Schitt's Creek to the IMDb ratings plot page, including a new episode ratings CSV and scraper registry entry so the data can be refreshed with the rest of the series data.

## Validation

- `RENV_CONFIG_AUTOLOADER_ENABLED=false Rscript` plot data/schema check
- `RENV_CONFIG_AUTOLOADER_ENABLED=false Rscript -e 'rmarkdown::render("imdb_rating_plot.Rmd", output_options = list(self_contained = FALSE), quiet = TRUE)'`

Note: the repo's default self-contained render still hits the existing absolute favicon path issue in `header/header.html`.