### PR TITLE
Add pre-push git hook mirroring cheap CI checks

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,276 @@
+#!/usr/bin/env bash
+#
+# Pre-push hook for cavandonohoe.github.io.
+#
+# Runs the cheap, deterministic slice of CI locally before a push so red
+# checks are caught in seconds instead of after a round-trip to GitHub:
+#
+#   1. typos      -> mirrors .github/workflows/typos.yml (.typos.toml)
+#   2. lintr      -> mirrors .github/workflows/lint.yml   (.lintr)
+#   3. testthat   -> mirrors .github/workflows/test.yml
+#   4. DESCRIPTION -> mirrors the build-workflow "library() vs DESCRIPTION"
+#                     sanity check
+#
+# Heavy CI jobs (site render, Lighthouse, pa11y, link-check) are NOT run
+# here: they need Chrome / a built _site / network and are too slow for a
+# push gate. Those stay on GitHub Actions.
+#
+# Only files that actually changed on the range being pushed are checked,
+# so day-to-day pushes stay fast.
+#
+# Escape hatches:
+#   git push --no-verify      # skip all hooks (git built-in)
+#   SKIP_HOOKS=1 git push     # same, explicit
+#   SKIP_LINT=1 / SKIP_TYPOS=1 / SKIP_TESTS=1 / SKIP_DESC=1  # skip one check
+
+set -uo pipefail
+
+if [ "${SKIP_HOOKS:-0}" = "1" ]; then
+  echo "pre-push: SKIP_HOOKS=1 set; skipping all checks."
+  exit 0
+fi
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root" || exit 1
+
+# ---------------------------------------------------------------------------
+# Figure out which local commits are being pushed, and derive the set of
+# changed files. git feeds the hook "<local ref> <local sha> <remote ref>
+# <remote sha>" lines on stdin, one per ref being pushed.
+# ---------------------------------------------------------------------------
+zero="0000000000000000000000000000000000000000"
+range_base=""
+range_tip="HEAD"
+have_range=0
+saw_stdin_ref=0
+
+while read -r local_ref local_sha remote_ref remote_sha; do
+  [ -z "${local_sha:-}" ] && continue
+  saw_stdin_ref=1
+  # Deleting a remote branch: nothing to check.
+  if [ "$local_sha" = "$zero" ]; then
+    continue
+  fi
+  range_tip="$local_sha"
+  if [ "$remote_sha" = "$zero" ]; then
+    # New branch on the remote. Diff against origin/main if we can, so we
+    # only look at this branch's own commits rather than all of history.
+    if git rev-parse --verify --quiet origin/main >/dev/null; then
+      range_base="$(git merge-base origin/main "$local_sha" 2>/dev/null || true)"
+    fi
+  else
+    range_base="$remote_sha"
+  fi
+  have_range=1
+done
+
+# stdin listed only branch deletions (or other no-op refs): nothing to push
+# content-wise, so let it through.
+if [ "$saw_stdin_ref" -eq 1 ] && [ "$have_range" -eq 0 ]; then
+  echo "pre-push: only ref deletions in this push; nothing to check."
+  exit 0
+fi
+
+# Fallbacks when stdin gave us nothing usable (e.g. manual invocation).
+if [ "$have_range" -eq 0 ]; then
+  range_tip="HEAD"
+fi
+if [ -z "$range_base" ]; then
+  if git rev-parse --verify --quiet origin/main >/dev/null; then
+    range_base="$(git merge-base origin/main "$range_tip" 2>/dev/null || true)"
+  fi
+fi
+if [ -z "$range_base" ]; then
+  range_base="$(git rev-parse "${range_tip}~1" 2>/dev/null || echo "$range_tip")"
+fi
+
+# macOS ships Bash 3.2 (no `mapfile`), so build the list the portable way.
+# Newline-delimited; paths with newlines are not a concern for this repo.
+changed_raw="$(
+  git diff --name-only --diff-filter=ACMR "$range_base" "$range_tip" 2>/dev/null \
+    | grep -Ev '^_archive/' || true
+)"
+
+# Changed R / Rmd files that still exist in the tree.
+r_files=()
+scripts_or_tests_changed=0
+description_relevant_changed=0
+while IFS= read -r f; do
+  [ -z "$f" ] && continue
+  case "$f" in
+    *.R | *.r | *.Rmd | *.rmd) [ -f "$f" ] && r_files+=("$f") ;;
+  esac
+  case "$f" in
+    scripts/*.R | scripts/*.r | tests/*) scripts_or_tests_changed=1 ;;
+  esac
+  case "$f" in
+    DESCRIPTION | *.Rmd | *.rmd) description_relevant_changed=1 ;;
+  esac
+done <<< "$changed_raw"
+
+fail=0
+
+echo "pre-push: checking ${range_base:0:7}..${range_tip:0:7}"
+
+# ---------------------------------------------------------------------------
+# 1. typos (fast; scans the whole tree via its own config excludes)
+# ---------------------------------------------------------------------------
+if [ "${SKIP_TYPOS:-0}" = "1" ]; then
+  echo "  [typos]   skipped (SKIP_TYPOS=1)"
+elif ! command -v typos >/dev/null 2>&1; then
+  echo "  [typos]   skipped (typos not installed; 'brew install typos-cli')"
+else
+  echo "  [typos]   running..."
+  if ! typos --config .typos.toml; then
+    echo "  [typos]   FAILED — fix the typos above or add them to .typos.toml"
+    fail=1
+  else
+    echo "  [typos]   ok"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# 2. lintr on changed R/Rmd files
+# ---------------------------------------------------------------------------
+if [ "${SKIP_LINT:-0}" = "1" ]; then
+  echo "  [lintr]   skipped (SKIP_LINT=1)"
+elif [ "${#r_files[@]}" -eq 0 ]; then
+  echo "  [lintr]   skipped (no R/Rmd files changed)"
+elif ! command -v Rscript >/dev/null 2>&1; then
+  echo "  [lintr]   skipped (Rscript not found)"
+else
+  echo "  [lintr]   linting ${#r_files[@]} file(s)..."
+  if ! LINT_FILES="$(printf '%s\n' "${r_files[@]}")" Rscript - <<'RSCRIPT'
+files <- strsplit(Sys.getenv("LINT_FILES"), "\n", fixed = TRUE)[[1]]
+files <- files[nzchar(files)]
+if (!requireNamespace("lintr", quietly = TRUE)) {
+  cat("    lintr not installed; skipping.\n")
+  quit(status = 0)
+}
+lints <- unlist(lapply(files, function(f) {
+  tryCatch(lintr::lint(f), error = function(e) {
+    message("    lintr error on ", f, ": ", conditionMessage(e))
+    list()
+  })
+}), recursive = FALSE)
+n <- length(lints)
+if (n > 0) {
+  print(structure(lints, class = "lints"))
+  cat("\n    Found", n, "lint(s).\n")
+  quit(status = 1)
+}
+cat("    No lints.\n")
+RSCRIPT
+  then
+    echo "  [lintr]   FAILED — fix the lints above (or tune .lintr)"
+    fail=1
+  else
+    echo "  [lintr]   ok"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# 3. testthat (only when scripts/ or tests/ changed)
+# ---------------------------------------------------------------------------
+if [ "${SKIP_TESTS:-0}" = "1" ]; then
+  echo "  [testthat] skipped (SKIP_TESTS=1)"
+elif [ "$scripts_or_tests_changed" -eq 0 ]; then
+  echo "  [testthat] skipped (no scripts/ or tests/ changes)"
+elif [ ! -d tests/testthat ]; then
+  echo "  [testthat] skipped (no tests/testthat dir)"
+elif ! command -v Rscript >/dev/null 2>&1; then
+  echo "  [testthat] skipped (Rscript not found)"
+else
+  echo "  [testthat] running..."
+  if ! Rscript - <<'RSCRIPT'
+if (!requireNamespace("testthat", quietly = TRUE)) {
+  cat("    testthat not installed; skipping.\n")
+  quit(status = 0)
+}
+results <- testthat::test_dir("tests/testthat", reporter = "summary")
+df <- as.data.frame(results)
+if (any(df$failed > 0) || any(df$error)) {
+  quit(status = 1)
+}
+RSCRIPT
+  then
+    echo "  [testthat] FAILED — fix the failing tests above"
+    fail=1
+  else
+    echo "  [testthat] ok"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# 4. DESCRIPTION: every library() call in an Rmd must be declared. Mirrors
+#    the build workflow's "Validate DESCRIPTION vs library() calls" step.
+#    Only runs when DESCRIPTION or an Rmd changed.
+# ---------------------------------------------------------------------------
+if [ "${SKIP_DESC:-0}" = "1" ]; then
+  echo "  [desc]    skipped (SKIP_DESC=1)"
+elif [ "$description_relevant_changed" -eq 0 ]; then
+  echo "  [desc]    skipped (no DESCRIPTION/Rmd changes)"
+elif ! command -v Rscript >/dev/null 2>&1; then
+  echo "  [desc]    skipped (Rscript not found)"
+else
+  echo "  [desc]    validating library() calls against DESCRIPTION..."
+  if ! Rscript - <<'RSCRIPT'
+desc <- read.dcf("DESCRIPTION")
+get_tokens <- function(field) {
+  if (!field %in% colnames(desc)) {
+    return(character())
+  }
+  x <- desc[, field]
+  if (length(x) == 0 || is.na(x)) {
+    return(character())
+  }
+  toks <- trimws(unlist(strsplit(x, ",\\s*")))
+  toks <- gsub("\\s*\\(.*\\)$", "", toks)
+  toks[nzchar(toks) & toks != "NA"]
+}
+declared <- unique(c(
+  get_tokens("Imports"), get_tokens("Depends"), get_tokens("Suggests")
+))
+declared <- declared[declared != "R"]
+rmds <- list.files(".", pattern = "\\.Rmd$", full.names = FALSE)
+libs_txt <- unlist(lapply(rmds, function(f) {
+  m <- regmatches(
+    readLines(f, warn = FALSE),
+    gregexpr("library\\(([^)]+)\\)", readLines(f, warn = FALSE))
+  )
+  unlist(m)
+}))
+libs <- unique(sub("^library\\(([^)]+)\\).*", "\\1", libs_txt))
+libs <- gsub("[\"' ]", "", libs)
+tv_core <- c(
+  "ggplot2", "dplyr", "tidyr", "readr", "purrr", "tibble", "stringr", "forcats"
+)
+if ("tidyverse" %in% declared) {
+  libs <- setdiff(libs, tv_core)
+}
+missing <- setdiff(libs, declared)
+if (length(missing)) {
+  cat("    ERROR: used via library() in an Rmd but not in DESCRIPTION:\n")
+  cat(paste0("      - ", missing), sep = "\n")
+  cat("\n")
+  quit(status = 1)
+}
+cat("    All library() packages are declared.\n")
+RSCRIPT
+  then
+    echo "  [desc]    FAILED — add the missing package(s) to DESCRIPTION Imports"
+    fail=1
+  else
+    echo "  [desc]    ok"
+  fi
+fi
+
+echo ""
+if [ "$fail" -ne 0 ]; then
+  echo "pre-push: checks FAILED. Fix the issues above, or bypass with:"
+  echo "  git push --no-verify"
+  exit 1
+fi
+
+echo "pre-push: all checks passed."
+exit 0

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -117,16 +117,69 @@ echo "pre-push: checking ${range_base:0:7}..${range_tip:0:7}"
 
 # ---------------------------------------------------------------------------
 # 1. typos on changed files
+#
+# typos does NOT apply `[files] extend-exclude` to paths passed explicitly on
+# the command line (it only honors excludes during directory traversal), so
+# we filter the changed set through the config's exclude globs ourselves.
+# Without this the hook could flag a file that CI (which scans the tree and
+# honors excludes) happily ignores, e.g. the auto-generated seed.sql.
 # ---------------------------------------------------------------------------
+typos_files=()
+if [ "${#changed_files[@]}" -gt 0 ] && command -v Rscript >/dev/null 2>&1 \
+  && [ -f .typos.toml ]; then
+  typos_kept="$(
+    CHANGED="$(printf '%s\n' "${changed_files[@]}")" \
+      RENV_CONFIG_AUTOLOADER_ENABLED=FALSE Rscript - <<'RSCRIPT'
+files <- strsplit(Sys.getenv("CHANGED"), "\n", fixed = TRUE)[[1]]
+files <- files[nzchar(files)]
+cfg <- readLines(".typos.toml", warn = FALSE)
+# Pull the quoted glob patterns out of the extend-exclude array.
+start <- grep("extend-exclude", cfg)
+pats <- character()
+if (length(start)) {
+  block <- cfg[start[1]:length(cfg)]
+  end <- grep("^\\]", block)
+  if (length(end)) block <- block[seq_len(end[1])]
+  m <- regmatches(block, gregexpr('"([^"]+)"', block))
+  pats <- gsub('"', "", unlist(m))
+}
+glob_to_regex <- function(p) {
+  # Order matters: protect ** before single *.
+  p <- gsub("\\.", "\\\\.", p)
+  p <- gsub("\\*\\*/", "\x01", p)   # **/  -> match any dirs (incl none)
+  p <- gsub("\\*\\*", "\x02", p)    # **   -> match anything
+  p <- gsub("\\*", "[^/]*", p)      # *    -> anything but a slash
+  p <- gsub("\x01", "(.*/)?", p)
+  p <- gsub("\x02", ".*", p)
+  paste0("^", p, "$")
+}
+regexes <- vapply(pats, glob_to_regex, character(1))
+excluded <- function(f) any(vapply(regexes, function(rx) {
+  grepl(rx, f)
+}, logical(1)))
+keep <- files[!vapply(files, excluded, logical(1))]
+cat(keep, sep = "\n")
+RSCRIPT
+  )"
+  while IFS= read -r kf; do
+    [ -n "$kf" ] && typos_files+=("$kf")
+  done <<< "$typos_kept"
+else
+  # No Rscript / no config: fall back to the raw changed set.
+  if [ "${#changed_files[@]}" -gt 0 ]; then
+    typos_files=("${changed_files[@]}")
+  fi
+fi
+
 if [ "${SKIP_TYPOS:-0}" = "1" ]; then
   echo "  [typos]   skipped (SKIP_TYPOS=1)"
-elif [ "${#changed_files[@]}" -eq 0 ]; then
-  echo "  [typos]   skipped (no files changed)"
+elif [ "${#typos_files[@]}" -eq 0 ]; then
+  echo "  [typos]   skipped (no non-excluded files changed)"
 elif ! command -v typos >/dev/null 2>&1; then
   echo "  [typos]   skipped (typos not installed; 'brew install typos-cli')"
 else
-  echo "  [typos]   checking ${#changed_files[@]} file(s)..."
-  if ! typos --config .typos.toml -- "${changed_files[@]}"; then
+  echo "  [typos]   checking ${#typos_files[@]} file(s)..."
+  if ! typos --config .typos.toml -- "${typos_files[@]}"; then
     echo "  [typos]   FAILED — fix the typos above or add them to .typos.toml"
     fail=1
   else
@@ -185,39 +238,7 @@ elif ! command -v Rscript >/dev/null 2>&1; then
   echo "  [testthat] skipped (Rscript not found)"
 else
   echo "  [testthat] running..."
-  if ! Rscript - <<'RSCRIPT'
-if (!requireNamespace("testthat", quietly = TRUE)) {
-  cat("    testthat not installed; skipping.\n")
-  quit(status = 0)
-}
-failed <- FALSE
-if (dir.exists("tests/testthat")) {
-  results <- testthat::test_dir("tests/testthat", reporter = "summary")
-  df <- as.data.frame(results)
-  failed <- failed || any(df$failed > 0) || any(df$error)
-} else {
-  cat("    No tests/testthat dir.\n")
-}
-flat_tests <- list.files("tests", pattern = "^test.*\\.R$", full.names = TRUE)
-if (length(flat_tests)) {
-  cat("    Running flat test file(s):\n")
-  for (f in flat_tests) {
-    cat("      - ", f, "\n", sep = "")
-    tryCatch(
-      sys.source(f, envir = new.env(parent = globalenv())),
-      error = function(e) {
-        message("    flat test failed in ", f, ": ", conditionMessage(e))
-        failed <<- TRUE
-      }
-    )
-  }
-} else {
-  cat("    No flat tests/test*.R files.\n")
-}
-if (failed) {
-  quit(status = 1)
-}
-RSCRIPT
+  if ! Rscript scripts/run_tests.R
   then
     echo "  [testthat] FAILED — fix the failing tests above"
     fail=1

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -15,18 +15,19 @@
 # here: they need Chrome / a built _site / network and are too slow for a
 # push gate. Those stay on GitHub Actions.
 #
-# Only files that actually changed on the range being pushed are checked,
-# so day-to-day pushes stay fast.
+# Only files that actually changed on the range being pushed are checked where
+# the underlying tool supports it, so day-to-day pushes stay fast.
 #
 # Escape hatches:
 #   git push --no-verify      # skip all hooks (git built-in)
 #   SKIP_HOOKS=1 git push     # same, explicit
+#   SKIP_PRE_PUSH=1 git push  # same, named for this hook
 #   SKIP_LINT=1 / SKIP_TYPOS=1 / SKIP_TESTS=1 / SKIP_DESC=1  # skip one check
 
 set -uo pipefail
 
-if [ "${SKIP_HOOKS:-0}" = "1" ]; then
-  echo "pre-push: SKIP_HOOKS=1 set; skipping all checks."
+if [ "${SKIP_HOOKS:-0}" = "1" ] || [ "${SKIP_PRE_PUSH:-0}" = "1" ]; then
+  echo "pre-push: SKIP_HOOKS=1 or SKIP_PRE_PUSH=1 set; skipping all checks."
   exit 0
 fi
 
@@ -91,12 +92,14 @@ changed_raw="$(
     | grep -Ev '^_archive/' || true
 )"
 
-# Changed R / Rmd files that still exist in the tree.
+# Changed files that still exist in the tree.
+changed_files=()
 r_files=()
 scripts_or_tests_changed=0
 description_relevant_changed=0
 while IFS= read -r f; do
   [ -z "$f" ] && continue
+  [ -f "$f" ] && changed_files+=("$f")
   case "$f" in
     *.R | *.r | *.Rmd | *.rmd) [ -f "$f" ] && r_files+=("$f") ;;
   esac
@@ -113,15 +116,17 @@ fail=0
 echo "pre-push: checking ${range_base:0:7}..${range_tip:0:7}"
 
 # ---------------------------------------------------------------------------
-# 1. typos (fast; scans the whole tree via its own config excludes)
+# 1. typos on changed files
 # ---------------------------------------------------------------------------
 if [ "${SKIP_TYPOS:-0}" = "1" ]; then
   echo "  [typos]   skipped (SKIP_TYPOS=1)"
+elif [ "${#changed_files[@]}" -eq 0 ]; then
+  echo "  [typos]   skipped (no files changed)"
 elif ! command -v typos >/dev/null 2>&1; then
   echo "  [typos]   skipped (typos not installed; 'brew install typos-cli')"
 else
-  echo "  [typos]   running..."
-  if ! typos --config .typos.toml; then
+  echo "  [typos]   checking ${#changed_files[@]} file(s)..."
+  if ! typos --config .typos.toml -- "${changed_files[@]}"; then
     echo "  [typos]   FAILED — fix the typos above or add them to .typos.toml"
     fail=1
   else
@@ -176,8 +181,6 @@ if [ "${SKIP_TESTS:-0}" = "1" ]; then
   echo "  [testthat] skipped (SKIP_TESTS=1)"
 elif [ "$scripts_or_tests_changed" -eq 0 ]; then
   echo "  [testthat] skipped (no scripts/ or tests/ changes)"
-elif [ ! -d tests/testthat ]; then
-  echo "  [testthat] skipped (no tests/testthat dir)"
 elif ! command -v Rscript >/dev/null 2>&1; then
   echo "  [testthat] skipped (Rscript not found)"
 else
@@ -187,9 +190,31 @@ if (!requireNamespace("testthat", quietly = TRUE)) {
   cat("    testthat not installed; skipping.\n")
   quit(status = 0)
 }
-results <- testthat::test_dir("tests/testthat", reporter = "summary")
-df <- as.data.frame(results)
-if (any(df$failed > 0) || any(df$error)) {
+failed <- FALSE
+if (dir.exists("tests/testthat")) {
+  results <- testthat::test_dir("tests/testthat", reporter = "summary")
+  df <- as.data.frame(results)
+  failed <- failed || any(df$failed > 0) || any(df$error)
+} else {
+  cat("    No tests/testthat dir.\n")
+}
+flat_tests <- list.files("tests", pattern = "^test.*\\.R$", full.names = TRUE)
+if (length(flat_tests)) {
+  cat("    Running flat test file(s):\n")
+  for (f in flat_tests) {
+    cat("      - ", f, "\n", sep = "")
+    tryCatch(
+      sys.source(f, envir = new.env(parent = globalenv())),
+      error = function(e) {
+        message("    flat test failed in ", f, ": ", conditionMessage(e))
+        failed <<- TRUE
+      }
+    )
+  }
+} else {
+  cat("    No flat tests/test*.R files.\n")
+}
+if (failed) {
   quit(status = 1)
 }
 RSCRIPT

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - ".githooks/pre-push"
       - "scripts/**/*.R"
+      - "scripts/run_tests.R"
       - "tests/**/*.R"
       - "tests/**/*.sh"
       - ".github/workflows/test.yml"
@@ -14,6 +15,7 @@ on:
     paths:
       - ".githooks/pre-push"
       - "scripts/**/*.R"
+      - "scripts/run_tests.R"
       - "tests/**/*.R"
       - "tests/**/*.sh"
       - ".github/workflows/test.yml"
@@ -52,20 +54,5 @@ jobs:
       - name: Run pre-push hook smoke test
         run: ./tests/test_pre_push_hook.sh
 
-      - name: Run testthat
-        run: |
-          Rscript -e '
-            failed <- FALSE
-            if (dir.exists("tests/testthat")) {
-              results <- testthat::test_dir("tests/testthat", reporter = "summary")
-              df <- as.data.frame(results)
-              failed <- failed || any(df$failed > 0) || any(df$error)
-            }
-            flat_tests <- list.files("tests", pattern = "^test.*\\.R$", full.names = TRUE)
-            for (f in flat_tests) {
-              sys.source(f, envir = new.env(parent = globalenv()))
-            }
-            if (failed) {
-              quit(status = 1)
-            }
-          '
+      - name: Run tests
+        run: Rscript scripts/run_tests.R

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,14 +4,18 @@ on:
   push:
     branches: [main]
     paths:
+      - ".githooks/pre-push"
       - "scripts/**/*.R"
       - "tests/**/*.R"
+      - "tests/**/*.sh"
       - ".github/workflows/test.yml"
   pull_request:
     branches: [main]
     paths:
+      - ".githooks/pre-push"
       - "scripts/**/*.R"
       - "tests/**/*.R"
+      - "tests/**/*.sh"
       - ".github/workflows/test.yml"
   workflow_dispatch:
 
@@ -45,12 +49,23 @@ jobs:
 
       - uses: r-lib/actions/setup-renv@v2
 
+      - name: Run pre-push hook smoke test
+        run: ./tests/test_pre_push_hook.sh
+
       - name: Run testthat
         run: |
           Rscript -e '
-            results <- testthat::test_dir("tests/testthat", reporter = "summary")
-            df <- as.data.frame(results)
-            if (any(df$failed > 0) || any(df$error)) {
+            failed <- FALSE
+            if (dir.exists("tests/testthat")) {
+              results <- testthat::test_dir("tests/testthat", reporter = "summary")
+              df <- as.data.frame(results)
+              failed <- failed || any(df$failed > 0) || any(df$error)
+            }
+            flat_tests <- list.files("tests", pattern = "^test.*\\.R$", full.names = TRUE)
+            for (f in flat_tests) {
+              sys.source(f, envir = new.env(parent = globalenv()))
+            }
+            if (failed) {
               quit(status = 1)
             }
           '

--- a/.typos.toml
+++ b/.typos.toml
@@ -43,6 +43,9 @@ ALO = "ALO"
 [files]
 extend-exclude = [
   ".git/**",
+  # Nested git repos (e.g. food-ranker/) are not submodules and their
+  # .git/objects blobs otherwise get scanned as binary noise.
+  "**/.git/**",
   "_archive/**",
   "_site/**",
   "**/*.pdf",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,11 +72,9 @@ lintr::lint("scripts/generate_sitemap.R")
 # Lint a directory
 lintr::lint_dir("scripts/")
 
-# Run the test suite (when tests are present)
-testthat::test_dir("tests/testthat")
-
-# Run a flat smoke test
-source("tests/test_chase_parser.R")
+# Run the full test suite (testthat dir + flat tests/test*.R) the same way
+# the pre-push hook and CI do
+Rscript scripts/run_tests.R
 ```
 
 For typo / link / accessibility checks see the corresponding workflows in `.github/workflows/`. These run automatically on PR.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,6 +74,9 @@ lintr::lint_dir("scripts/")
 
 # Run the test suite (when tests are present)
 testthat::test_dir("tests/testthat")
+
+# Run a flat smoke test
+source("tests/test_chase_parser.R")
 ```
 
 For typo / link / accessibility checks see the corresponding workflows in `.github/workflows/`. These run automatically on PR.
@@ -89,12 +92,12 @@ instead of after a round-trip to GitHub. Enable it once after cloning:
 ```
 
 That points `core.hooksPath` at the tracked `.githooks/` directory, so the
-hook is versioned and shared. On each `git push` it runs, against only the
-files changed in the range being pushed:
+hook is versioned and shared. On each `git push` it runs against the files
+changed in the range being pushed:
 
 - **typos** — spell check via `.typos.toml` (mirrors `typos.yml`)
 - **lintr** — lints changed `.R` / `.Rmd` files via `.lintr` (mirrors `lint.yml`)
-- **testthat** — runs `tests/testthat` when `scripts/` or `tests/` changed (mirrors `test.yml`)
+- **testthat** — runs `tests/testthat` and flat `tests/test*.R` files when `scripts/` or `tests/` changed (mirrors `test.yml`)
 - **DESCRIPTION** — checks every `library()` call in an Rmd is declared (mirrors the build sanity check)
 
 Heavy jobs (site render, Lighthouse, pa11y, link-check) stay on CI; they
@@ -105,6 +108,7 @@ Bypass when you need to:
 ```bash
 git push --no-verify          # skip all hooks
 SKIP_HOOKS=1 git push         # same, explicit
+SKIP_PRE_PUSH=1 git push      # same, named for this hook
 SKIP_LINT=1 git push          # skip just lintr (also SKIP_TYPOS / SKIP_TESTS / SKIP_DESC)
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,6 +78,36 @@ testthat::test_dir("tests/testthat")
 
 For typo / link / accessibility checks see the corresponding workflows in `.github/workflows/`. These run automatically on PR.
 
+## Git hooks (pre-push)
+
+The repo ships a pre-push hook (`.githooks/pre-push`) that runs the fast,
+deterministic slice of CI locally so red checks are caught before the push
+instead of after a round-trip to GitHub. Enable it once after cloning:
+
+```bash
+./scripts/install-git-hooks.sh
+```
+
+That points `core.hooksPath` at the tracked `.githooks/` directory, so the
+hook is versioned and shared. On each `git push` it runs, against only the
+files changed in the range being pushed:
+
+- **typos** — spell check via `.typos.toml` (mirrors `typos.yml`)
+- **lintr** — lints changed `.R` / `.Rmd` files via `.lintr` (mirrors `lint.yml`)
+- **testthat** — runs `tests/testthat` when `scripts/` or `tests/` changed (mirrors `test.yml`)
+- **DESCRIPTION** — checks every `library()` call in an Rmd is declared (mirrors the build sanity check)
+
+Heavy jobs (site render, Lighthouse, pa11y, link-check) stay on CI; they
+need Chrome / a built `_site` / network and are too slow for a push gate.
+
+Bypass when you need to:
+
+```bash
+git push --no-verify          # skip all hooks
+SKIP_HOOKS=1 git push         # same, explicit
+SKIP_LINT=1 git push          # skip just lintr (also SKIP_TYPOS / SKIP_TESTS / SKIP_DESC)
+```
+
 ## Bumping pinned dependencies
 
 The renv lockfile (`renv.lock`) is the source of truth for what

--- a/scripts/install-git-hooks.sh
+++ b/scripts/install-git-hooks.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+#
+# Enable the repo's tracked git hooks (see .githooks/).
+#
+# Run once after cloning:
+#   ./scripts/install-git-hooks.sh
+#
+# This points git at the tracked .githooks/ directory instead of the
+# per-clone .git/hooks/, so the hooks are versioned and shared. Undo with:
+#   git config --unset core.hooksPath
+
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+chmod +x .githooks/* 2>/dev/null || true
+git config core.hooksPath .githooks
+
+echo "Enabled git hooks from .githooks/ (core.hooksPath set)."
+echo "Bypass any run with:  git push --no-verify"

--- a/scripts/run_tests.R
+++ b/scripts/run_tests.R
@@ -1,0 +1,61 @@
+#!/usr/bin/env Rscript
+#
+# Shared test runner used by both the pre-push hook (.githooks/pre-push)
+# and CI (.github/workflows/test.yml) so the two never diverge.
+#
+# Runs, and fails (exit 1) on any failure from:
+#   1. testthat suite in tests/testthat/ (if present)
+#   2. flat tests/test*.R files
+#
+# Flat files are sourced from the repo root (so their relative paths such
+# as source("scripts/..") and readLines("tests/fixtures/..") resolve) while
+# an active testthat reporter counts failures. This catches BOTH bare
+# stop()/stopifnot() errors AND test_that() expectation failures, unlike a
+# plain sys.source() which only surfaces thrown errors.
+
+if (!requireNamespace("testthat", quietly = TRUE)) {
+  cat("    testthat not installed; skipping.\n")
+  quit(status = 0)
+}
+
+failed <- FALSE
+
+if (dir.exists("tests/testthat")) {
+  results <- testthat::test_dir("tests/testthat", reporter = "summary")
+  df <- as.data.frame(results)
+  failed <- failed || any(df$failed > 0) || any(df$error)
+} else {
+  cat("    No tests/testthat dir.\n")
+}
+
+flat_tests <- list.files("tests", pattern = "^test.*\\.R$", full.names = TRUE)
+if (length(flat_tests)) {
+  cat("    Running flat test file(s):\n")
+  for (f in flat_tests) {
+    cat("      - ", f, "\n", sep = "")
+    reporter <- testthat::ListReporter$new()
+    file_failed <- tryCatch({
+      testthat::with_reporter(reporter, {
+        sys.source(f, envir = new.env(parent = globalenv()))
+      })
+      FALSE
+    }, error = function(e) {
+      message("    flat test errored in ", f, ": ", conditionMessage(e))
+      TRUE
+    })
+    res <- as.data.frame(reporter$get_results())
+    if (nrow(res) && (any(res$failed > 0) || any(res$error))) {
+      file_failed <- TRUE
+    }
+    if (file_failed) {
+      failed <- TRUE
+    }
+  }
+} else {
+  cat("    No flat tests/test*.R files.\n")
+}
+
+if (failed) {
+  quit(status = 1)
+}
+cat("    All tests passed.\n")

--- a/tests/test_pre_push_hook.sh
+++ b/tests/test_pre_push_hook.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+hook="$repo_root/.githooks/pre-push"
+zero="0000000000000000000000000000000000000000"
+
+bash -n "$hook"
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+cp "$hook" "$tmp/pre-push"
+chmod +x "$tmp/pre-push"
+
+run_hook() {
+  SKIP_TYPOS=1 SKIP_LINT=1 SKIP_TESTS=1 SKIP_DESC=1 "$tmp/pre-push"
+}
+
+git -C "$tmp" init -q
+git -C "$tmp" config user.email "hook-test@example.com"
+git -C "$tmp" config user.name "Hook Test"
+
+printf 'one\n' > "$tmp/file.txt"
+git -C "$tmp" add file.txt
+git -C "$tmp" commit -q -m "Initial commit"
+git -C "$tmp" branch -M main
+git -C "$tmp" update-ref refs/remotes/origin/main HEAD
+main_sha="$(git -C "$tmp" rev-parse HEAD)"
+
+printf 'two\n' >> "$tmp/file.txt"
+git -C "$tmp" commit -q -am "Update main"
+main_tip="$(git -C "$tmp" rev-parse HEAD)"
+printf 'refs/heads/main %s refs/heads/main %s\n' "$main_tip" "$main_sha" | (cd "$tmp" && run_hook)
+
+git -C "$tmp" checkout -q -b feature "$main_sha"
+printf 'feature\n' > "$tmp/feature.txt"
+git -C "$tmp" add feature.txt
+git -C "$tmp" commit -q -m "Feature commit"
+feature_tip="$(git -C "$tmp" rev-parse HEAD)"
+printf 'refs/heads/feature %s refs/heads/feature %s\n' "$feature_tip" "$zero" | (cd "$tmp" && run_hook)
+
+printf 'refs/heads/old %s refs/heads/old %s\n' "$zero" "$main_tip" | (cd "$tmp" && "$tmp/pre-push")
+(cd "$tmp" && run_hook < /dev/null)
+(cd "$tmp" && SKIP_PRE_PUSH=1 "$tmp/pre-push" < /dev/null)
+(cd "$tmp" && SKIP_HOOKS=1 "$tmp/pre-push" < /dev/null)
+
+echo "pre-push hook smoke tests passed."


### PR DESCRIPTION
## Summary

Adds a tracked pre-push git hook that runs the fast, deterministic slice of CI locally before each push, so red checks are caught in seconds instead of after a round-trip to GitHub.

On each push it checks **only the files in the push range** and runs:

- **typos** — spell check via `.typos.toml` (mirrors `typos.yml`)
- **lintr** — lints changed `.R` / `.Rmd` files via `.lintr` (mirrors `lint.yml`)
- **testthat** — runs `tests/testthat` when `scripts/` or `tests/` changed (mirrors `test.yml`)
- **DESCRIPTION** — verifies every `library()` call in an Rmd is declared (mirrors the build sanity check)

Heavy CI jobs (site render, Lighthouse, pa11y, link-check) stay on GitHub Actions; they need Chrome / a built `_site` / network and are too slow for a push gate.

## Details

- Hook lives in `.githooks/pre-push` (tracked/versioned) and is enabled via `scripts/install-git-hooks.sh`, which sets `core.hooksPath`.
- Bash 3.2 compatible (macOS default; no `mapfile`).
- Handles new-branch, existing-branch, delete-only, and manual-invocation push scenarios.
- Bypass with `git push --no-verify`, `SKIP_HOOKS=1`, or per-check `SKIP_LINT` / `SKIP_TYPOS` / `SKIP_TESTS` / `SKIP_DESC`.
- `.typos.toml`: excludes nested `.git` dirs (the un-submoduled `food-ranker/.git` was polluting typos with binary object blobs).
- Documented the setup, checks, and bypass flags in `CONTRIBUTING.md`.

## Test plan

- [x] `bash -n` syntax check on both scripts
- [x] Hook runs and passes on a clean range
- [x] Hook correctly fails on real lints / typos
- [x] `SKIP_HOOKS=1`, empty-range, and delete-only scenarios short-circuit cleanly
- [x] Verified live: this branch's own push ran the hook and passed