### PR TITLE
Extract shared setup-r-env composite action for CI

### DIFF
--- a/.github/actions/setup-r-env/action.yml
+++ b/.github/actions/setup-r-env/action.yml
@@ -1,0 +1,84 @@
+name: Set up R environment
+description: >-
+  Install R (public RSPM), the OS libraries every renv-locked package in this
+  repo needs, restore the renv library, and hard-fail if the restore is
+  incomplete. Replaces the setup-r + apt + setup-renv + restore-guard block that
+  was copy-pasted across every R workflow.
+
+inputs:
+  r-version:
+    description: R version passed to r-lib/actions/setup-r (e.g. '4.6', 'release').
+    required: false
+    default: "4.6"
+  pandoc-version:
+    description: >-
+      Pandoc version to install. Leave empty to skip installing pandoc via
+      setup-pandoc (the apt 'pandoc' package is always installed as a fallback).
+    required: false
+    default: ""
+  restore:
+    description: >-
+      Whether to run setup-renv + the restore completeness guard. Set to 'false'
+      for jobs that only need R + system libs (no locked library).
+    required: false
+    default: "true"
+
+runs:
+  using: composite
+  steps:
+    - uses: r-lib/actions/setup-r@v2
+      with:
+        use-public-rspm: true
+        r-version: ${{ inputs.r-version }}
+
+    - if: ${{ inputs.pandoc-version != '' }}
+      uses: r-lib/actions/setup-pandoc@v2
+      with:
+        pandoc-version: ${{ inputs.pandoc-version }}
+
+    # System libraries for the compiled packages in renv.lock. Keep this list in
+    # sync with the project's dependency tree (units/sf -> gdal/geos/proj/udunits,
+    # pdftools -> poppler, magick -> imagemagick, rsvg -> librsvg).
+    - name: Install system dependencies
+      shell: bash
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y \
+          cmake git libcurl4-openssl-dev libfontconfig1-dev libfreetype6-dev \
+          libfribidi-dev libgdal-dev libgeos-dev libgit2-dev libharfbuzz-dev \
+          libicu-dev libjpeg-dev libmagick++-dev libnode-dev libpng-dev \
+          libpoppler-cpp-dev libproj-dev librsvg2-dev libssl-dev libtiff-dev \
+          libudunits2-dev libuv1-dev libwebp-dev libx11-dev libxml2-dev make \
+          pandoc zlib1g-dev
+
+    - if: ${{ inputs.restore == 'true' }}
+      uses: r-lib/actions/setup-renv@v2
+
+    # setup-renv's internal renv::restore() only *warns* on a failed package
+    # download (e.g. a transient Posit Package Manager hiccup), so a job can
+    # continue with an incomplete library and only die later with a confusing
+    # "there is no package called X". Retry restore explicitly, then hard-fail if
+    # anything recorded in the lockfile is still missing.
+    - if: ${{ inputs.restore == 'true' }}
+      name: Ensure renv library is complete
+      shell: bash
+      # Force the autoloader on for this restore even if the caller disabled it
+      # at the job level (some workflows set RENV_CONFIG_AUTOLOADER_ENABLED=FALSE
+      # to skip setup-renv's implicit restore); the guard must target the project
+      # library.
+      env:
+        RENV_CONFIG_AUTOLOADER_ENABLED: "TRUE"
+      run: |
+        Rscript -e '
+          ok <- FALSE
+          for (i in 1:3) {
+            tryCatch({
+              renv::restore(prompt = FALSE)
+              st <- renv::status()
+              if (isTRUE(st$synchronized)) { ok <- TRUE; break }
+            }, error = function(e) message("restore attempt ", i, " failed: ", conditionMessage(e)))
+            message("renv library incomplete; retrying (", i, "/3)...")
+            Sys.sleep(15)
+          }
+          if (!isTRUE(ok)) stop("renv::restore() could not install all lockfile packages after 3 attempts")
+        '

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,23 +31,7 @@ jobs:
         run: |
           git fetch --no-tags --depth=1 origin "${{ github.event.pull_request.base.ref || 'main' }}"
 
-      - uses: r-lib/actions/setup-r@v2
-        with:
-          use-public-rspm: true
-          r-version: '4.6'
-
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            cmake git libcurl4-openssl-dev libfontconfig1-dev libfreetype6-dev \
-            libfribidi-dev libgdal-dev libgeos-dev libgit2-dev libharfbuzz-dev \
-            libicu-dev libjpeg-dev libmagick++-dev libnode-dev libpng-dev \
-            libpoppler-cpp-dev libproj-dev librsvg2-dev libssl-dev libtiff-dev \
-            libudunits2-dev libuv1-dev libwebp-dev libx11-dev libxml2-dev make \
-            pandoc zlib1g-dev
-
-      - uses: r-lib/actions/setup-renv@v2
+      - uses: ./.github/actions/setup-r-env
 
       - name: Run lintr on changed files
         run: |

--- a/.github/workflows/pages-branch-previews.yml
+++ b/.github/workflows/pages-branch-previews.yml
@@ -33,13 +33,8 @@ jobs:
         with:
           ref: ${{ github.sha }}
 
-      # --- R / Pandoc like your working workflow ---
-      - uses: r-lib/actions/setup-r@v2
-        with:
-          use-public-rspm: true
-          r-version: '4.6'
-
-      - uses: r-lib/actions/setup-pandoc@v2
+      # --- R / Pandoc / system libs / renv restore via shared composite ---
+      - uses: ./.github/actions/setup-r-env
         with:
           pandoc-version: "3.1.11"
 
@@ -54,39 +49,6 @@ jobs:
           cat("Imports tokens:\n"); print(toks)
           if (length(bad)) stop("Bad Imports tokens (contain spaces): ", paste(bad, collapse=", "))
           RSCRIPT
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            cmake git libcurl4-openssl-dev libfontconfig1-dev libfreetype6-dev \
-            libfribidi-dev libgdal-dev libgeos-dev libgit2-dev libharfbuzz-dev \
-            libicu-dev libjpeg-dev libmagick++-dev libnode-dev libpng-dev \
-            libpoppler-cpp-dev libproj-dev librsvg2-dev libssl-dev libtiff-dev \
-            libudunits2-dev libuv1-dev libwebp-dev libx11-dev libxml2-dev make \
-            pandoc zlib1g-dev
-
-      - uses: r-lib/actions/setup-renv@v2
-
-      # setup-renv's internal renv::restore() only *warns* on a failed package
-      # download (e.g. a transient Posit Package Manager hiccup), so the job can
-      # continue with an incomplete library and only die later with a confusing
-      # "there is no package called X". Retry restore explicitly, then hard-fail
-      # if anything recorded in the lockfile is still missing.
-      - name: Ensure renv library is complete
-        run: |
-          Rscript -e '
-            ok <- FALSE
-            for (i in 1:3) {
-              tryCatch({
-                renv::restore(prompt = FALSE)
-                st <- renv::status()
-                if (isTRUE(st$synchronized)) { ok <- TRUE; break }
-              }, error = function(e) message("restore attempt ", i, " failed: ", conditionMessage(e)))
-              message("renv library incomplete; retrying (", i, "/3)...")
-              Sys.sleep(15)
-            }
-            if (!isTRUE(ok)) stop("renv::restore() could not install all lockfile packages after 3 attempts")
-          '
 
       # ✅ Write SA key to runner temp for same-repo PRs, pushes, and manual
       # dispatches (forks won't get secrets). NOTE: Dependabot PRs run with

--- a/.github/workflows/pages-rmarkdown.yml
+++ b/.github/workflows/pages-rmarkdown.yml
@@ -37,12 +37,9 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: r-lib/actions/setup-r@v2
+      - uses: ./.github/actions/setup-r-env
         with:
-          use-public-rspm: true
-          r-version: '4.6'
-
-      - uses: r-lib/actions/setup-pandoc@v2
+          pandoc-version: "3.8.3"
 
       - name: Validate DESCRIPTION tokenization
         run: |
@@ -54,39 +51,6 @@ jobs:
           cat("Imports tokens:\n"); print(toks)
           if (length(bad)) stop("Bad Imports tokens (contain spaces): ", paste(bad, collapse=", "))
           RSCRIPT
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            cmake git libcurl4-openssl-dev libfontconfig1-dev libfreetype6-dev \
-            libfribidi-dev libgdal-dev libgeos-dev libgit2-dev libharfbuzz-dev \
-            libicu-dev libjpeg-dev libmagick++-dev libnode-dev libpng-dev \
-            libpoppler-cpp-dev libproj-dev librsvg2-dev libssl-dev libtiff-dev \
-            libudunits2-dev libuv1-dev libwebp-dev libx11-dev libxml2-dev make \
-            pandoc zlib1g-dev
-
-      - uses: r-lib/actions/setup-renv@v2
-
-      # setup-renv's internal renv::restore() only *warns* on a failed package
-      # download (e.g. a transient Posit Package Manager hiccup), so the job can
-      # continue with an incomplete library and only die later with a confusing
-      # "there is no package called X". Retry restore explicitly, then hard-fail
-      # if anything recorded in the lockfile is still missing.
-      - name: Ensure renv library is complete
-        run: |
-          Rscript -e '
-            ok <- FALSE
-            for (i in 1:3) {
-              tryCatch({
-                renv::restore(prompt = FALSE)
-                st <- renv::status()
-                if (isTRUE(st$synchronized)) { ok <- TRUE; break }
-              }, error = function(e) message("restore attempt ", i, " failed: ", conditionMessage(e)))
-              message("renv library incomplete; retrying (", i, "/3)...")
-              Sys.sleep(15)
-            }
-            if (!isTRUE(ok)) stop("renv::restore() could not install all lockfile packages after 3 attempts")
-          '
       # --- Write SA key from repo secret (skip on Dependabot/forks: no secrets) ---
       - name: Write GCP key
         if: ${{ github.actor != 'dependabot[bot]' }}

--- a/.github/workflows/pr-smoke.yml
+++ b/.github/workflows/pr-smoke.yml
@@ -57,28 +57,10 @@ jobs:
             echo "$changed"
           fi
 
-      - uses: r-lib/actions/setup-r@v2
+      - uses: ./.github/actions/setup-r-env
         if: ${{ steps.changed.outputs.files != '' }}
         with:
-          use-public-rspm: true
-          r-version: '4.6'
-
-      - uses: r-lib/actions/setup-pandoc@v2
-        if: ${{ steps.changed.outputs.files != '' }}
-      - name: Install system dependencies
-        if: ${{ steps.changed.outputs.files != '' }}
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            cmake git libcurl4-openssl-dev libfontconfig1-dev libfreetype6-dev \
-            libfribidi-dev libgdal-dev libgeos-dev libgit2-dev libharfbuzz-dev \
-            libicu-dev libjpeg-dev libmagick++-dev libnode-dev libpng-dev \
-            libpoppler-cpp-dev libproj-dev librsvg2-dev libssl-dev libtiff-dev \
-            libudunits2-dev libuv1-dev libwebp-dev libx11-dev libxml2-dev make \
-            pandoc zlib1g-dev
-
-      - uses: r-lib/actions/setup-renv@v2
-        if: ${{ steps.changed.outputs.files != '' }}
+          pandoc-version: "3.8.3"
 
       - name: Write GCP key (same-repo PRs only)
         if: |

--- a/.github/workflows/rebuild_cv.yml
+++ b/.github/workflows/rebuild_cv.yml
@@ -28,24 +28,9 @@ jobs:
           [ -f cv.pdf ] && cp cv.pdf .cv-pre/cv.pdf || true
           [ -f cv_doc.docx ] && cp cv_doc.docx .cv-pre/cv_doc.docx || true
 
-      - uses: r-lib/actions/setup-r@v2
+      - uses: ./.github/actions/setup-r-env
         with:
-          use-public-rspm: true
-          r-version: '4.6'
-
-      - uses: r-lib/actions/setup-pandoc@v2
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            cmake git libcurl4-openssl-dev libfontconfig1-dev libfreetype6-dev \
-            libfribidi-dev libgdal-dev libgeos-dev libgit2-dev libharfbuzz-dev \
-            libicu-dev libjpeg-dev libmagick++-dev libnode-dev libpng-dev \
-            libpoppler-cpp-dev libproj-dev librsvg2-dev libssl-dev libtiff-dev \
-            libudunits2-dev libuv1-dev libwebp-dev libx11-dev libxml2-dev make \
-            pandoc zlib1g-dev
-
-      - uses: r-lib/actions/setup-renv@v2
+          pandoc-version: "3.8.3"
 
       - name: Write GCP key
         run: |

--- a/.github/workflows/refresh-sitemap.yml
+++ b/.github/workflows/refresh-sitemap.yml
@@ -20,23 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: r-lib/actions/setup-r@v2
-        with:
-          use-public-rspm: true
-          r-version: '4.6'
-
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            cmake git libcurl4-openssl-dev libfontconfig1-dev libfreetype6-dev \
-            libfribidi-dev libgdal-dev libgeos-dev libgit2-dev libharfbuzz-dev \
-            libicu-dev libjpeg-dev libmagick++-dev libnode-dev libpng-dev \
-            libpoppler-cpp-dev libproj-dev librsvg2-dev libssl-dev libtiff-dev \
-            libudunits2-dev libuv1-dev libwebp-dev libx11-dev libxml2-dev make \
-            pandoc zlib1g-dev
-
-      - uses: r-lib/actions/setup-renv@v2
+      - uses: ./.github/actions/setup-r-env
 
       - name: Regenerate sitemap.xml
         run: Rscript scripts/generate_sitemap.R

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,23 +35,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: r-lib/actions/setup-r@v2
-        with:
-          use-public-rspm: true
-          r-version: '4.6'
-
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            cmake git libcurl4-openssl-dev libfontconfig1-dev libfreetype6-dev \
-            libfribidi-dev libgdal-dev libgeos-dev libgit2-dev libharfbuzz-dev \
-            libicu-dev libjpeg-dev libmagick++-dev libnode-dev libpng-dev \
-            libpoppler-cpp-dev libproj-dev librsvg2-dev libssl-dev libtiff-dev \
-            libudunits2-dev libuv1-dev libwebp-dev libx11-dev libxml2-dev make \
-            pandoc zlib1g-dev
-
-      - uses: r-lib/actions/setup-renv@v2
+      - uses: ./.github/actions/setup-r-env
 
       - name: Run pre-push hook smoke test
         run: ./tests/test_pre_push_hook.sh

--- a/.github/workflows/update_best_picture_winners.yml
+++ b/.github/workflows/update_best_picture_winners.yml
@@ -15,23 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: r-lib/actions/setup-r@v2
-        with:
-          use-public-rspm: true
-          r-version: '4.6'
-
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            cmake git libcurl4-openssl-dev libfontconfig1-dev libfreetype6-dev \
-            libfribidi-dev libgdal-dev libgeos-dev libgit2-dev libharfbuzz-dev \
-            libicu-dev libjpeg-dev libmagick++-dev libnode-dev libpng-dev \
-            libpoppler-cpp-dev libproj-dev librsvg2-dev libssl-dev libtiff-dev \
-            libudunits2-dev libuv1-dev libwebp-dev libx11-dev libxml2-dev make \
-            pandoc zlib1g-dev
-
-      - uses: r-lib/actions/setup-renv@v2
+      - uses: ./.github/actions/setup-r-env
 
       - name: Refresh Best Picture winners
         run: Rscript scripts/check_best_picture_winners.R

--- a/.github/workflows/update_director_filmographies.yml
+++ b/.github/workflows/update_director_filmographies.yml
@@ -22,23 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: r-lib/actions/setup-r@v2
-        with:
-          use-public-rspm: true
-          r-version: '4.6'
-
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            cmake git libcurl4-openssl-dev libfontconfig1-dev libfreetype6-dev \
-            libfribidi-dev libgdal-dev libgeos-dev libgit2-dev libharfbuzz-dev \
-            libicu-dev libjpeg-dev libmagick++-dev libnode-dev libpng-dev \
-            libpoppler-cpp-dev libproj-dev librsvg2-dev libssl-dev libtiff-dev \
-            libudunits2-dev libuv1-dev libwebp-dev libx11-dev libxml2-dev make \
-            pandoc zlib1g-dev
-
-      - uses: r-lib/actions/setup-renv@v2
+      - uses: ./.github/actions/setup-r-env
 
       - name: Refresh director filmographies
         env:

--- a/.github/workflows/update_imdb_ratings.yml
+++ b/.github/workflows/update_imdb_ratings.yml
@@ -22,23 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: r-lib/actions/setup-r@v2
-        with:
-          use-public-rspm: true
-          r-version: '4.6'
-
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            cmake git libcurl4-openssl-dev libfontconfig1-dev libfreetype6-dev \
-            libfribidi-dev libgdal-dev libgeos-dev libgit2-dev libharfbuzz-dev \
-            libicu-dev libjpeg-dev libmagick++-dev libnode-dev libpng-dev \
-            libpoppler-cpp-dev libproj-dev librsvg2-dev libssl-dev libtiff-dev \
-            libudunits2-dev libuv1-dev libwebp-dev libx11-dev libxml2-dev make \
-            pandoc zlib1g-dev
-
-      - uses: r-lib/actions/setup-renv@v2
+      - uses: ./.github/actions/setup-r-env
 
       # Run the scraper. Per-show errors are swallowed by the script's safety
       # wrapper; if any show fails the script exits non-zero and we stop here.

--- a/.github/workflows/update_movie_ranker_personal.yml
+++ b/.github/workflows/update_movie_ranker_personal.yml
@@ -48,48 +48,7 @@ jobs:
             exit 1
           fi
 
-      - uses: r-lib/actions/setup-r@v2
-        with:
-          use-public-rspm: true
-          r-version: '4.6'
-
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            cmake git libcurl4-openssl-dev libfontconfig1-dev libfreetype6-dev \
-            libfribidi-dev libgdal-dev libgeos-dev libgit2-dev libharfbuzz-dev \
-            libicu-dev libjpeg-dev libmagick++-dev libnode-dev libpng-dev \
-            libpoppler-cpp-dev libproj-dev librsvg2-dev libssl-dev libtiff-dev \
-            libudunits2-dev libuv1-dev libwebp-dev libx11-dev libxml2-dev make \
-            pandoc zlib1g-dev
-
-      - uses: r-lib/actions/setup-renv@v2
-
-      # setup-renv's internal renv::restore() only *warns* on a failed package
-      # download (e.g. a transient Posit Package Manager hiccup), so the job can
-      # continue with an incomplete library and only die later with a confusing
-      # "there is no package called X". Retry restore explicitly (with the renv
-      # autoloader on so it targets the project library), then hard-fail if any
-      # package the script needs is still missing. RENV_CONFIG_AUTOLOADER_ENABLED
-      # is FALSE at the job level, so enable it just for this restore call.
-      - name: Ensure renv library is complete
-        env:
-          RENV_CONFIG_AUTOLOADER_ENABLED: "TRUE"
-        run: |
-          Rscript -e '
-            ok <- FALSE
-            for (i in 1:3) {
-              tryCatch({
-                renv::restore(prompt = FALSE)
-                st <- renv::status()
-                if (isTRUE(st$synchronized)) { ok <- TRUE; break }
-              }, error = function(e) message("restore attempt ", i, " failed: ", conditionMessage(e)))
-              message("renv library incomplete; retrying (", i, "/3)...")
-              Sys.sleep(15)
-            }
-            if (!isTRUE(ok)) stop("renv::restore() could not install all lockfile packages after 3 attempts")
-          '
+      - uses: ./.github/actions/setup-r-env
 
       # Confirm the packages the script needs load in the same environment the
       # script runs in (autoloader disabled, default .libPaths()).

--- a/.github/workflows/update_sp500.yml
+++ b/.github/workflows/update_sp500.yml
@@ -20,23 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: r-lib/actions/setup-r@v2
-        with:
-          use-public-rspm: true
-          r-version: '4.6'
-
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            cmake git libcurl4-openssl-dev libfontconfig1-dev libfreetype6-dev \
-            libfribidi-dev libgdal-dev libgeos-dev libgit2-dev libharfbuzz-dev \
-            libicu-dev libjpeg-dev libmagick++-dev libnode-dev libpng-dev \
-            libpoppler-cpp-dev libproj-dev librsvg2-dev libssl-dev libtiff-dev \
-            libudunits2-dev libuv1-dev libwebp-dev libx11-dev libxml2-dev make \
-            pandoc zlib1g-dev
-
-      - uses: r-lib/actions/setup-renv@v2
+      - uses: ./.github/actions/setup-r-env
 
       - name: Refresh VOO stock prices
         run: Rscript scripts/sp500_data.R

--- a/.github/workflows/update_top1000_box_office.yml
+++ b/.github/workflows/update_top1000_box_office.yml
@@ -19,23 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: r-lib/actions/setup-r@v2
-        with:
-          use-public-rspm: true
-          r-version: '4.6'
-
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            cmake git libcurl4-openssl-dev libfontconfig1-dev libfreetype6-dev \
-            libfribidi-dev libgdal-dev libgeos-dev libgit2-dev libharfbuzz-dev \
-            libicu-dev libjpeg-dev libmagick++-dev libnode-dev libpng-dev \
-            libpoppler-cpp-dev libproj-dev librsvg2-dev libssl-dev libtiff-dev \
-            libudunits2-dev libuv1-dev libwebp-dev libx11-dev libxml2-dev make \
-            pandoc zlib1g-dev
-
-      - uses: r-lib/actions/setup-renv@v2
+      - uses: ./.github/actions/setup-r-env
 
       - name: Refresh Best Picture + Top 1000 box office
         env:

--- a/.github/workflows/update_top250_with_rt.yml
+++ b/.github/workflows/update_top250_with_rt.yml
@@ -19,23 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: r-lib/actions/setup-r@v2
-        with:
-          use-public-rspm: true
-          r-version: '4.6'
-
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            cmake git libcurl4-openssl-dev libfontconfig1-dev libfreetype6-dev \
-            libfribidi-dev libgdal-dev libgeos-dev libgit2-dev libharfbuzz-dev \
-            libicu-dev libjpeg-dev libmagick++-dev libnode-dev libpng-dev \
-            libpoppler-cpp-dev libproj-dev librsvg2-dev libssl-dev libtiff-dev \
-            libudunits2-dev libuv1-dev libwebp-dev libx11-dev libxml2-dev make \
-            pandoc zlib1g-dev
-
-      - uses: r-lib/actions/setup-renv@v2
+      - uses: ./.github/actions/setup-r-env
 
       - name: Refresh Top 250 with Rotten Tomatoes
         run: Rscript scripts/refresh_top250_with_rt.R

--- a/.github/workflows/update_us_rentals.yml
+++ b/.github/workflows/update_us_rentals.yml
@@ -20,23 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: r-lib/actions/setup-r@v2
-        with:
-          use-public-rspm: true
-          r-version: '4.6'
-
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            cmake git libcurl4-openssl-dev libfontconfig1-dev libfreetype6-dev \
-            libfribidi-dev libgdal-dev libgeos-dev libgit2-dev libharfbuzz-dev \
-            libicu-dev libjpeg-dev libmagick++-dev libnode-dev libpng-dev \
-            libpoppler-cpp-dev libproj-dev librsvg2-dev libssl-dev libtiff-dev \
-            libudunits2-dev libuv1-dev libwebp-dev libx11-dev libxml2-dev make \
-            pandoc zlib1g-dev
-
-      - uses: r-lib/actions/setup-renv@v2
+      - uses: ./.github/actions/setup-r-env
 
       - name: Refresh US rental markets
         run: Rscript scripts/us_rental_markets_data.R


### PR DESCRIPTION
## Summary
- Follow-up to #135. That PR had to touch 15 workflows by hand just to add system libraries, because every R workflow copy-pasted the same `setup-r` + apt system-deps + `setup-renv` block (and three also duplicated the renv restore-completeness guard).
- Introduces `.github/actions/setup-r-env`, a composite action that bundles all of it, so the next dependency change is a one-file edit.

## What the composite does
- `r-lib/actions/setup-r` with `use-public-rspm: true` and an `r-version` input (default `4.6`).
- Optional `r-lib/actions/setup-pandoc` via a `pandoc-version` input (empty = rely on the apt `pandoc` package).
- Installs the full OS library list the locked package tree needs (gdal/geos/proj/udunits for units/sf, poppler for pdftools, imagemagick for magick, librsvg for rsvg, etc.).
- `setup-renv` + the retry/fail-fast restore guard, toggleable with a `restore` input.

## Behavior preserved per workflow
- **pages-branch-previews**: pandoc pinned to `3.1.11`.
- **rebuild_cv, pr-smoke, pages-rmarkdown**: pandoc `3.8.3` (matches the old unpinned `setup-pandoc@v2` default).
- **pr-smoke**: the `changed-files` conditional now gates the single composite step.
- **update_movie_ranker_personal**: job-level `RENV_CONFIG_AUTOLOADER_ENABLED=FALSE` still skips setup-renv's implicit restore; the guard forces the autoloader on for its explicit restore.

## Test plan
- [ ] All migrated workflows run green on this PR (Build site, R tests, R lint, pr-smoke, etc.).
- [ ] `actionlint` clean (only a pre-existing SC2012 in `update_imdb_ratings.yml`, unrelated).
- [ ] Confirm every workflow still checks out the repo before invoking the local composite.