### PR TITLE
movie-ranker: replace magic-link login with local password gate

### DIFF
--- a/movie-ranker/.env.local.example
+++ b/movie-ranker/.env.local.example
@@ -1,3 +1,9 @@
 NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
 SUPABASE_SERVICE_ROLE_KEY=your-service-role-key-server-only
+
+# Local single-user password login. RANKER_EMAIL is the account whose session
+# gets minted on a correct password; RANKER_PASS is the password you type on
+# /login. Both stay in this gitignored file only.
+RANKER_EMAIL=you@example.com
+RANKER_PASS=change-me

--- a/movie-ranker/src/app/actions/auth.ts
+++ b/movie-ranker/src/app/actions/auth.ts
@@ -3,10 +3,54 @@
 import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
+import { createServiceClient } from "@/lib/supabase/admin";
 
 export async function signOutAction() {
   const supabase = createClient();
   await supabase.auth.signOut();
   revalidatePath("/", "layout");
   redirect("/");
+}
+
+// Local, single-user password login. The password lives only in the
+// gitignored `.env.local` (`RANKER_PASS`), never in the committed source, so
+// the public repo leaks nothing. On a match we mint a real Supabase session
+// for the fixed ranker account (`RANKER_EMAIL`) server-side via the service
+// role — no email is sent, so there is no rate limit — and the SSR client
+// writes the session cookies. This keeps `auth.uid()` working for RLS.
+export async function passwordLoginAction(formData: FormData) {
+  const password = String(formData.get("password") ?? "");
+  const next = String(formData.get("next") ?? "/compare");
+
+  const expected = process.env.RANKER_PASS;
+  const email = process.env.RANKER_EMAIL;
+  if (!expected || !email) {
+    redirect(`/login?error=${encodeURIComponent("Server is missing RANKER_PASS / RANKER_EMAIL")}`);
+  }
+  if (password !== expected) {
+    redirect(`/login?error=${encodeURIComponent("Wrong password")}`);
+  }
+
+  const admin = createServiceClient();
+  const { data, error: linkError } = await admin.auth.admin.generateLink({
+    type: "magiclink",
+    email: email!
+  });
+  if (linkError || !data?.properties?.hashed_token) {
+    redirect(
+      `/login?error=${encodeURIComponent(linkError?.message ?? "Could not create session")}`
+    );
+  }
+
+  const supabase = createClient();
+  const { error: verifyError } = await supabase.auth.verifyOtp({
+    type: "magiclink",
+    token_hash: data!.properties.hashed_token
+  });
+  if (verifyError) {
+    redirect(`/login?error=${encodeURIComponent(verifyError.message)}`);
+  }
+
+  revalidatePath("/", "layout");
+  redirect(next);
 }

--- a/movie-ranker/src/app/login/page.tsx
+++ b/movie-ranker/src/app/login/page.tsx
@@ -1,109 +1,47 @@
-"use client";
+import { passwordLoginAction } from "@/app/actions/auth";
 
-import { Suspense, useMemo, useState } from "react";
-import { useSearchParams } from "next/navigation";
-import { createClient } from "@/lib/supabase/client";
-
-function LoginInner() {
-  const supabase = useMemo(() => createClient(), []);
-  const searchParams = useSearchParams();
-  const next = searchParams.get("next") ?? "/compare";
-
-  const [email, setEmail] = useState("");
-  const [status, setStatus] = useState<"idle" | "sending" | "sent" | "error">(
-    "idle"
-  );
-  const [error, setError] = useState<string | null>(null);
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!email.trim()) return;
-    setStatus("sending");
-    setError(null);
-
-    const redirectTo = `${window.location.origin}/auth/callback?next=${encodeURIComponent(
-      next
-    )}`;
-    const { error: signInError } = await supabase.auth.signInWithOtp({
-      email: email.trim(),
-      options: { emailRedirectTo: redirectTo }
-    });
-
-    if (signInError) {
-      setStatus("error");
-      setError(signInError.message);
-      return;
-    }
-    setStatus("sent");
-  };
+export default function LoginPage({
+  searchParams
+}: {
+  searchParams: { next?: string; error?: string };
+}) {
+  const next = searchParams.next ?? "/compare";
+  const error = searchParams.error ?? null;
 
   return (
     <section className="mx-auto flex min-h-[70vh] max-w-md flex-col justify-center">
       <h1 className="font-display text-4xl font-semibold tracking-tight sm:text-5xl">
         Sign in
       </h1>
-      <p className="mt-2 text-mist">
-        Magic link, no password. Your rankings stay yours.
-      </p>
+      <p className="mt-2 text-mist">Enter the password to unlock ranking.</p>
 
-      {status === "sent" ? (
-        <div className="mt-8 rounded-2xl border border-white/5 bg-slate p-6">
-          <h2 className="font-display text-2xl font-semibold">
-            Check your inbox
-          </h2>
-          <p className="mt-2 text-sm text-mist">
-            We just sent a magic link to{" "}
-            <span className="font-medium text-ink">{email}</span>. Click it on
-            this device to sign in.
-          </p>
-          <button
-            type="button"
-            onClick={() => setStatus("idle")}
-            className="mt-4 text-xs uppercase tracking-[0.18em] text-gold hover:underline"
-          >
-            Use a different email
-          </button>
-        </div>
-      ) : (
-        <form onSubmit={handleSubmit} className="mt-8 space-y-4">
-          <label className="block">
-            <span className="mb-1.5 block text-xs font-medium uppercase tracking-[0.18em] text-mist">
-              Email
-            </span>
-            <input
-              type="email"
-              required
-              autoFocus
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              placeholder="you@example.com"
-              className="w-full rounded-xl border border-white/10 bg-slate px-4 py-3 text-base text-ink placeholder:text-mist/50 focus:border-white/30 focus:outline-none focus:ring-2 focus:ring-gold/30"
-            />
-          </label>
+      <form action={passwordLoginAction} className="mt-8 space-y-4">
+        <input type="hidden" name="next" value={next} />
+        <label className="block">
+          <span className="mb-1.5 block text-xs font-medium uppercase tracking-[0.18em] text-mist">
+            Password
+          </span>
+          <input
+            type="password"
+            name="password"
+            required
+            autoFocus
+            placeholder="••••"
+            className="w-full rounded-xl border border-white/10 bg-slate px-4 py-3 text-base text-ink placeholder:text-mist/50 focus:border-white/30 focus:outline-none focus:ring-2 focus:ring-gold/30"
+          />
+        </label>
 
-          {error && (
-            <p className="rounded-xl bg-ember/10 p-3 text-sm text-ember">
-              {error}
-            </p>
-          )}
+        {error && (
+          <p className="rounded-xl bg-ember/10 p-3 text-sm text-ember">{error}</p>
+        )}
 
-          <button
-            type="submit"
-            disabled={status === "sending"}
-            className="inline-flex w-full items-center justify-center rounded-full bg-gold px-7 py-4 text-base font-semibold text-cream shadow-card transition hover:bg-ember hover:text-ink disabled:cursor-not-allowed disabled:opacity-60"
-          >
-            {status === "sending" ? "Sending…" : "Send magic link"}
-          </button>
-        </form>
-      )}
+        <button
+          type="submit"
+          className="inline-flex w-full items-center justify-center rounded-full bg-gold px-7 py-4 text-base font-semibold text-cream shadow-card transition hover:bg-ember hover:text-ink"
+        >
+          Unlock
+        </button>
+      </form>
     </section>
-  );
-}
-
-export default function LoginPage() {
-  return (
-    <Suspense fallback={null}>
-      <LoginInner />
-    </Suspense>
   );
 }

--- a/movie-ranker/src/lib/supabase/admin.ts
+++ b/movie-ranker/src/lib/supabase/admin.ts
@@ -1,0 +1,19 @@
+import { createClient as createAdminClient } from "@supabase/supabase-js";
+import type { Database } from "../database.types";
+
+// Service-role client for privileged, server-only operations (e.g. minting a
+// session for the single ranker account after a local password check). Never
+// import this from client components — the service role key must stay on the
+// server.
+export function createServiceClient() {
+  return createAdminClient<Database>(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+    {
+      auth: {
+        autoRefreshToken: false,
+        persistSession: false
+      }
+    }
+  );
+}

--- a/movie-ranker/supabase/schema.sql
+++ b/movie-ranker/supabase/schema.sql
@@ -70,14 +70,18 @@ create policy "titles_read_all"
   using (true);
 
 -- Global Elo updates flow through Server Actions running with the user's
--- session; allow update from any authenticated user. Inserts/deletes are
--- managed offline via the seed/import script with the service role key.
+-- session. Only the owner account may move the shared global Elo, so a
+-- stranger who signs up cannot rewrite the global leaderboard. Their own
+-- personal comparisons/overrides are still isolated by the policies below.
+-- Inserts/deletes are managed offline via the seed/import script with the
+-- service role key. Replace the uuid with your own auth.users id.
 drop policy if exists "titles_update_authed" on public.titles;
-create policy "titles_update_authed"
+drop policy if exists "titles_update_owner" on public.titles;
+create policy "titles_update_owner"
   on public.titles for update
   to authenticated
-  using (true)
-  with check (true);
+  using (auth.uid() = '48bd53ba-ad7b-4291-82c5-13a34b989b52'::uuid)
+  with check (auth.uid() = '48bd53ba-ad7b-4291-82c5-13a34b989b52'::uuid);
 
 drop policy if exists "comparisons_read_own" on public.comparisons;
 create policy "comparisons_read_own"


### PR DESCRIPTION
## Summary

Replaces the email magic-link login on `/login` with a single-user password gate.

- The password lives only in the gitignored `.env.local` (`RANKER_PASS`), never in the committed source, so the public repo leaks nothing.
- On a correct password, a server action mints a real Supabase session for the fixed ranker account (`RANKER_EMAIL`) server-side via the service role (`generateLink` + `verifyOtp`). No email is sent, so there is no rate limit, and `auth.uid()` still works for RLS.

## Changes

- Add server-only service-role client `lib/supabase/admin.ts` (`persistSession: false`, never imported from client components).
- Add `passwordLoginAction` / `signOutAction` server actions in `app/actions/auth.ts`.
- Convert `/login` from a `"use client"` magic-link form to a server component with a password form posting to the action.
- Tighten the `titles` UPDATE RLS policy from any authenticated user to owner-only, so a random signup cannot rewrite the shared global Elo leaderboard. Personal comparisons/overrides stay isolated by the existing per-user policies.
- Document `RANKER_EMAIL` / `RANKER_PASS` in `.env.local.example`.

## Notes

- `tsc --noEmit` passes.
- The owner UUID is embedded in `schema.sql` (with a comment to replace it with your own `auth.users` id). It is a user id, not a secret.