### PR TITLE
Add Batman: The Animated Series to IMDb rating plot

### DIFF
--- a/data/batman_animated_series_ep_ratings.csv
+++ b/data/batman_animated_series_ep_ratings.csv
@@ -1,0 +1,86 @@
+season,episode,title,rating,votes
+1,1,The Cat and the Claw: Part 1,7.7,4443
+1,2,On Leather Wings,7.6,5212
+1,3,Heart of Ice,9,5348
+1,4,Feat of Clay: Part 1,8.3,3885
+1,5,Feat of Clay: Part 2,8.6,3893
+1,6,It's Never Too Late,7.6,3624
+1,7,Joker's Favor,8.5,3862
+1,8,The Cat and the Claw: Part 2,7.6,3524
+1,9,Pretty Poison,7.9,3857
+1,10,Nothing to Fear,8,4114
+1,11,Be a Clown,7.5,3415
+1,12,Appointment in Crime Alley,7.6,3007
+1,13,P.O.V.,7.5,3432
+1,14,The Clock King,7.6,2961
+1,15,The Last Laugh,7.7,3593
+1,16,Eternal Youth,7.3,2750
+1,17,Two-Face: Part 1,9.1,4549
+1,18,Two-Face: Part 2,9,4277
+1,19,Fear of Victory,7.6,2777
+1,20,I've Got Batman in My Basement,6.5,3051
+1,21,Vendetta,7.5,2719
+1,22,Prophecy of Doom,6.7,2674
+1,23,The Forgotten,7.2,3074
+1,24,Mad as a Hatter,8,2855
+1,25,The Cape and Cowl Conspiracy,7.5,2596
+1,26,Perchance to Dream,9,3373
+1,27,The Underdwellers,6.7,3034
+1,28,Night of the Ninja,7.5,2475
+1,29,The Strange Secret of Bruce Wayne,8.2,2607
+1,30,Tyger Tyger,7,2400
+1,31,Dreams in Darkness,8.3,2686
+1,32,Beware the Gray Ghost,8.9,3532
+1,33,Cat Scratch Fever,7.2,2346
+1,34,I Am the Night,8.6,2680
+1,35,Almost Got 'im,9.2,3670
+1,36,Moon of the Wolf,6.7,2263
+1,37,Terror in the Sky,7.3,2250
+1,38,Christmas with the Joker,7.9,3858
+1,39,Heart of Steel: Part 1,7.8,2344
+1,40,Heart of Steel: Part 2,7.9,2336
+1,41,"If You're So Smart, Why Aren't You Rich?",8.3,2558
+1,42,Joker's Wild,8.2,2440
+1,43,His Silicon Soul,8.2,2257
+1,44,Off Balance,7.6,2180
+1,45,What Is Reality?,7.7,2260
+1,46,The Laughing Fish,8.5,2603
+1,47,Harley and Ivy,8.6,2516
+1,48,The Mechanic,7.5,2110
+1,49,The Man Who Killed Batman,8.8,2663
+1,50,Zatanna,7.8,2225
+1,51,Robin's Reckoning: Part I,8.7,2629
+1,52,Birds of a Feather,7.7,2124
+1,53,Robin's Reckoning: Part II,8.6,2506
+1,54,Blind as a Bat,7.3,1992
+1,55,Day of the Samurai,7.8,2140
+1,56,See No Evil,7.7,2378
+1,57,The Demon's Quest: Part I,8.3,2196
+1,58,The Demon's Quest: Part II,8.3,2164
+1,59,Read My Lips,8.4,2187
+1,60,Fire from Olympus,6.9,2016
+2,1,Shadow of the Bat: Part 1,8.3,2207
+2,2,Shadow of the Bat: Part 2,8.3,2160
+2,3,Mudslide,8.1,2159
+2,4,The Worry Men,7.2,1944
+2,5,Paging the Crime Doctor,7.5,1995
+2,6,House & Garden,8.3,2033
+2,7,Sideshow,7.8,1944
+2,8,Avatar,7.5,1883
+2,9,Trial,9.1,2561
+2,10,Harlequinade,8.6,2156
+3,1,Bane,8.1,2071
+3,2,Second Chance,8.5,2187
+3,3,Riddler's Reform,8,1939
+3,4,Baby-Doll,7.8,2070
+3,5,Time Out of Joint,7.4,1816
+3,6,Harley's Holiday,8.6,2105
+3,7,Make 'Em Laugh,7.5,1826
+3,8,Batgirl Returns,7.6,1814
+3,9,Lock-Up,7.5,1828
+3,10,Deep Freeze,8.2,1942
+4,1,The Terrible Trio,6.7,1824
+4,2,Showdown,7.5,1864
+4,3,Catwalk,7.7,1817
+4,4,A Bullet for Bullock,8.1,1962
+4,5,The Lion and the Unicorn,7.2,1731

--- a/imdb_rating_plot.Rmd
+++ b/imdb_rating_plot.Rmd
@@ -622,4 +622,16 @@ batman_caped_crusader %>%
   interactive_plotly
 ```
 
+## Batman: The Animated Series
+
+```{r fig.height=14, fig.width=7}
+batman_animated_series <- readr::read_csv(
+  "data/batman_animated_series_ep_ratings.csv"
+)
+
+batman_animated_series %>%
+  create_episode_plot("Batman: The Animated Series") %>%
+  interactive_plotly
+```
+
 [Raw pngs found here](https://github.com/cavandonohoe/cavandonohoe.github.io/tree/gh-pages/imdb_rating_plot_files)

--- a/web_scraping/imdb_season_episode_ratings_plot.R
+++ b/web_scraping/imdb_season_episode_ratings_plot.R
@@ -340,7 +340,8 @@ shows <- tibble::tribble(
   "my hero academia",   "tt5626028",   "my_hero_academia",
   "the boys",           "tt1190634",   "the_boys",
   "schitt's creek",     "tt3526078",   "schitts_creek",
-  "batman caped crusader", "tt14681596", "batman_caped_crusader"
+  "batman caped crusader", "tt14681596", "batman_caped_crusader",
+  "batman the animated series", "tt0103359", "batman_animated_series"
 )
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds **Batman: The Animated Series** (IMDb `tt0103359`) to the IMDb season/episode rating plot.

- New `data/batman_animated_series_ep_ratings.csv` with all episodes across the show's 4 seasons, fetched via the existing IMDb GraphQL scraper.
- Added the show to the `shows` config in `web_scraping/imdb_season_episode_ratings_plot.R` so the auto-update cron keeps it fresh.
- Added a new section chunk in `imdb_rating_plot.Rmd` (grouped right after Batman: Caped Crusader).

## Notes
- Season 1 is long, so the chunk uses `fig.height=14, fig.width=7` to keep every episode legible, following the same pattern as other tall/wide shows (Death Note, Simpsons).
- The heatmap PNG regenerates on render (gitignored, like the others).
- Both changed files lint clean; pre-push hook passes with no bypass.