### PR TITLE
Add Ted Lasso, Rick and Morty, and Gravity Falls to IMDb rating plot

### DIFF
--- a/data/gravity_falls_ep_ratings.csv
+++ b/data/gravity_falls_ep_ratings.csv
@@ -1,0 +1,42 @@
+season,episode,title,rating,votes
+1,1,Tourist Trapped,8.2,6284
+1,2,The Legend of the Gobblewonker,7.7,5717
+1,3,Headhunters,7.9,5411
+1,4,The Hand That Rocks the Mabel,7.6,5181
+1,5,The Inconveniencing,8.5,5312
+1,6,Dipper vs. Manliness,7.7,5073
+1,7,Double Dipper,8.6,5235
+1,8,Irrational Treasure,8.1,4887
+1,9,The Time Traveler's Pig,9,5395
+1,10,Fight Fighters,8.5,4978
+1,11,Little Dipper,7.8,4645
+1,12,Summerween,8.6,5029
+1,13,Boss Mabel,7.7,4627
+1,14,Bottomless Pit!,8,4651
+1,15,The Deep End,7.6,4608
+1,16,Carpet Diem,8.5,4622
+1,17,Boyz Crazy,7.2,4653
+1,18,Land Before Swine,8.3,4532
+1,19,Dreamscaperers,9.3,5424
+1,20,Gideon Rises,9.3,5356
+2,1,Scary-oke,8.8,4983
+2,2,Into the Bunker,9.3,5330
+2,3,The Golf War,8.1,4636
+2,4,Sock Opera,8.7,4900
+2,5,Soos and the Real Girl,8.6,4776
+2,6,Little Gift Shop of Horrors,7.7,4463
+2,7,Society of the Blind Eye,9.2,5144
+2,8,Blendin's Game,9,4832
+2,9,The Love God,7.5,4437
+2,10,Northwest Mansion Mystery,9.2,5616
+2,11,Not What He Seems,9.8,10955
+2,12,A Tale of Two Stans,9.6,6653
+2,13,"Dungeons, Dungeons, and More Dungeons",8.3,4497
+2,14,The Stanchurian Candidate,8,4307
+2,15,The Last Mabelcorn,8.8,4667
+2,16,Roadside Attraction,7.8,4413
+2,17,Dipper and Mabel vs. the Future,9.3,5335
+2,18,Weirdmageddon Part 1,9.5,5941
+2,19,Weirdmageddon 2: Escape from Reality,9.4,5536
+2,20,Weirdmageddon 3: Take Back the Falls,9.8,11146
+2,21,Weirdmageddon 4: Somewhere in the Woods,9.8,8001

--- a/data/rick_and_morty_ep_ratings.csv
+++ b/data/rick_and_morty_ep_ratings.csv
@@ -1,0 +1,92 @@
+season,episode,title,rating,votes
+1,1,Pilot,7.9,22275
+1,2,Lawnmower Dog,8.6,21853
+1,3,Anatomy Park,8.2,20052
+1,4,M. Night Shaym-Aliens!,8.6,20027
+1,5,Meeseeks and Destroy,9,22164
+1,6,Rick Potion #9,9.1,22002
+1,7,Raising Gazorpazorp,7.8,18308
+1,8,Rixty Minutes,8.6,19992
+1,9,Something Ricked This Way Comes,8.3,18112
+1,10,Close Rick-Counters of the Rick Kind,9.3,22885
+1,11,Ricksy Business,8.4,17840
+2,1,A Rickle in Time,8.8,19800
+2,2,Mortynight Run,8.8,18689
+2,3,Auto Erotic Assimilation,8.5,18111
+2,4,Total Rickall,9.5,25910
+2,5,Get Schwifty,8.2,18021
+2,6,The Ricks Must Be Crazy,9.3,21628
+2,7,Big Trouble in Little Sanchez,8.4,17024
+2,8,Interdimensional Cable 2: Tempting Fate,7.6,17507
+2,9,Look Who's Purging Now,8.5,17525
+2,10,The Wedding Squanchers,9.3,21301
+3,1,The Rickshank Rickdemption,9.6,30711
+3,2,Rickmancing the Stone,8.1,17859
+3,3,Pickle Rick,9.4,27220
+3,4,Vindicators 3: The Return of Worldender,8.1,17712
+3,5,The Whirly Dirly Conspiracy,8.4,17010
+3,6,Rest and Ricklaxation,8.8,18529
+3,7,The Ricklantis Mixup,9.8,44225
+3,8,Morty's Mind Blowers,8.9,18231
+3,9,The ABCs of Beth,7.8,15716
+3,10,The Rickchurian Mortydate,8.2,15908
+4,1,Edge of Tomorty: Rick Die Rickpeat,8.9,19584
+4,2,The Old Man and the Seat,8.3,17511
+4,3,One Crew over the Crewcoo's Morty,8.2,16887
+4,4,Claw and Hoarder: Special Ricktim's Morty,7.3,17110
+4,5,Rattlestar Ricklactica,8.8,16730
+4,6,Never Ricking Morty,8,15758
+4,7,Promortyus,8,13634
+4,8,The Vat of Acid Episode,9.5,21371
+4,9,Childrick of Mort,7.7,13341
+4,10,Star Mort Rickturn of the Jerri,9,15436
+5,1,Mort Dinner Rick Andre,9,19307
+5,2,Mortyplicity,8.7,17109
+5,3,A Rickconvenient Mort,7.8,15656
+5,4,Rickdependence Spray,5.7,17681
+5,5,Amortycan Grickfitti,7,13016
+5,6,Rick & Morty's Thanksploitation Spectacular,7.1,13239
+5,7,Gotron Jerrysis Rickvangelion,6.3,12772
+5,8,Rickternal Friendshine of the Spotless Mort,8.2,13092
+5,9,Forgetting Sarick Mortshall,8.2,11876
+5,10,Rickmurai Jack,9.3,17820
+6,1,Solaricks,8.6,13485
+6,2,Rick: A Mort Well Lived,7.8,11089
+6,3,Bethic Twinstinct,7.7,11610
+6,4,Night Family,8.5,12041
+6,5,Final DeSmithation,8.2,10670
+6,6,Juricksic Mort,7.8,9997
+6,7,Full Meta Jackrick,7.8,9893
+6,8,Analyze Piss,8.4,9920
+6,9,A Rick in King Mortur's Mort,7.4,8844
+6,10,Ricktional Mortpoon's Rickmas Mortcation,8,8805
+7,1,How Poopy Got His Poop Back,6.2,12349
+7,2,The Jerrick Trap,7.3,10480
+7,3,Air Force Wong,6.8,9940
+7,4,That's Amorte,8.4,12450
+7,5,Unmortricken,9.2,15621
+7,6,Rickfending Your Mort,7.8,9546
+7,7,Wet Kuat Amortican Summer,6.4,9114
+7,8,Rise of the Numbericons: The Movie,4.4,12208
+7,9,Mort: Ragnarick,7.9,9515
+7,10,Fear No Mort,9.4,15434
+8,1,Summer of All Fears,8.3,10214
+8,2,Valkyrick,7.1,7881
+8,3,"The Rick, The Mort & The Ugly",7.9,8409
+8,4,The Last Temptation of Jerry,6.3,7647
+8,5,Cryo Mort a Rickver,7.1,6746
+8,6,The Curicksous Case of Bethjamin Button,7.4,6797
+8,7,Ricker Than Fiction,6.7,6403
+8,8,Nomortland,8,6913
+8,9,Morty Daddy,6.6,5554
+8,10,Hot Rick,8.9,8285
+9,1,There's Something About Morty,8.8,9509
+9,2,"Ricks Days, Seven Nights",8.7,7949
+9,3,Rick Fu Hustle,7.1,6277
+9,4,A Ricker Runs Through It,7.5,5245
+9,5,Jer Bud,7.6,4721
+9,6,Erickerhead,8,4745
+9,7,Mortgully: The Last Rickforest,9.2,6734
+9,8,Rickuiem Mort a Dream,8.4,4075
+9,9,Salute Your Morts,7.5,3275
+9,10,Field of Dreams,9.4,3618

--- a/data/ted_lasso_ep_ratings.csv
+++ b/data/ted_lasso_ep_ratings.csv
@@ -1,0 +1,35 @@
+season,episode,title,rating,votes
+1,1,Pilot,7.8,11278
+1,2,Biscuits,8.1,10070
+1,3,Trent Crimm: The Independent,8.5,10127
+1,4,For the Children,8.2,9729
+1,5,Tan Lines,8.9,10246
+1,6,Two Aces,8.5,9316
+1,7,Make Rebecca Great Again,9,10715
+1,8,The Diamond Dogs,8.7,9447
+1,9,All Apologies,8.6,8787
+1,10,The Hope That Kills You,9.1,10619
+2,1,Goodbye Earl,7.6,8980
+2,2,Lavender,8,8249
+2,3,Do the Right-est Thing,8.4,9003
+2,4,Carol of the Bells,8.6,10975
+2,5,Rainbow,8.9,9919
+2,6,The Signal,8.6,8188
+2,7,Headspace,7.7,7779
+2,8,Man City,9,10483
+2,9,Beard After Hours,6.9,17520
+2,10,No Weddings and a Funeral,8.5,9666
+2,11,Midnight Train to Royston,8.2,7592
+2,12,Inverting the Pyramid of Success,8.8,8749
+3,1,Smells Like Mean Spirit,7.7,8241
+3,2,(I Don't Want to Go to) Chelsea,8.2,7737
+3,3,4-5-1,7.8,7645
+3,4,Big Week,8.1,7189
+3,5,Signs,7.2,7741
+3,6,Sunflowers,8.9,13870
+3,7,The Strings That Bind Us,8.3,8988
+3,8,We'll Never Have Paris,6.7,8749
+3,9,La Locker Room Aux Folles,8.5,8839
+3,10,International Break,8.5,8623
+3,11,Mom City,9.3,12492
+3,12,"So Long, Farewell",9.4,15386

--- a/imdb_rating_plot.Rmd
+++ b/imdb_rating_plot.Rmd
@@ -634,4 +634,34 @@ batman_animated_series %>%
   interactive_plotly
 ```
 
+## Ted Lasso
+
+```{r}
+ted_lasso <- readr::read_csv("data/ted_lasso_ep_ratings.csv")
+
+ted_lasso %>%
+  create_episode_plot("Ted Lasso") %>%
+  interactive_plotly
+```
+
+## Rick and Morty
+
+```{r}
+rick_and_morty <- readr::read_csv("data/rick_and_morty_ep_ratings.csv")
+
+rick_and_morty %>%
+  create_episode_plot("Rick and Morty") %>%
+  interactive_plotly
+```
+
+## Gravity Falls
+
+```{r fig.height=8}
+gravity_falls <- readr::read_csv("data/gravity_falls_ep_ratings.csv")
+
+gravity_falls %>%
+  create_episode_plot("Gravity Falls") %>%
+  interactive_plotly
+```
+
 [Raw pngs found here](https://github.com/cavandonohoe/cavandonohoe.github.io/tree/gh-pages/imdb_rating_plot_files)

--- a/web_scraping/imdb_season_episode_ratings_plot.R
+++ b/web_scraping/imdb_season_episode_ratings_plot.R
@@ -341,7 +341,10 @@ shows <- tibble::tribble(
   "the boys",           "tt1190634",   "the_boys",
   "schitt's creek",     "tt3526078",   "schitts_creek",
   "batman caped crusader", "tt14681596", "batman_caped_crusader",
-  "batman the animated series", "tt0103359", "batman_animated_series"
+  "batman the animated series", "tt0103359", "batman_animated_series",
+  "ted lasso",          "tt10986410",  "ted_lasso",
+  "rick and morty",     "tt2861424",   "rick_and_morty",
+  "gravity falls",      "tt1865718",   "gravity_falls"
 )
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds three shows to the IMDb season/episode rating plot:

- **Ted Lasso** (IMDb `tt10986410`)
- **Rick and Morty** (IMDb `tt2861424`)
- **Gravity Falls** (IMDb `tt1865718`)

Each addition follows the established pattern:
- New `data/<slug>_ep_ratings.csv` with per-episode ratings, fetched via the existing IMDb GraphQL scraper.
- Added to the `shows` config in `web_scraping/imdb_season_episode_ratings_plot.R` so the auto-update cron keeps them fresh.
- New section chunk in `imdb_rating_plot.Rmd`.

## Notes
- Gravity Falls uses `fig.height=8` since its seasons run to ~21 episodes; Ted Lasso and Rick and Morty use the default dimensions.
- Heatmap PNGs regenerate on render (gitignored, like the others).
- All three plots render successfully; both changed source files lint clean and the pre-push hook passes with no bypass.