### PR TITLE
ci: replace Node 20 PR-comment action with native gh sticky comment

### DIFF
--- a/.github/scripts/sticky-comment.sh
+++ b/.github/scripts/sticky-comment.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Post or update a single "sticky" comment on a pull request, keyed by a
+# hidden HTML marker. Replaces thollander/actions-comment-pull-request so we
+# don't depend on a Node 20 action (deprecated on GitHub Actions runners).
+#
+# Required env:
+#   GH_TOKEN    - token with pull-requests: write
+#   PR_NUMBER   - pull request number
+#   STICKY_TAG  - unique tag identifying this comment (e.g. "repo-size")
+# Body source (exactly one):
+#   BODY_FILE   - path to a file whose contents become the comment body, or
+#   BODY        - literal comment body string
+set -euo pipefail
+
+: "${GH_TOKEN:?GH_TOKEN is required}"
+: "${PR_NUMBER:?PR_NUMBER is required}"
+: "${STICKY_TAG:?STICKY_TAG is required}"
+
+marker="<!-- sticky-comment: ${STICKY_TAG} -->"
+
+if [ -n "${BODY_FILE:-}" ]; then
+  body_content="$(cat "$BODY_FILE")"
+elif [ -n "${BODY:-}" ]; then
+  body_content="$BODY"
+else
+  echo "Either BODY_FILE or BODY must be set" >&2
+  exit 1
+fi
+
+full_body="${marker}"$'\n'"${body_content}"
+
+repo="${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
+
+# Find an existing sticky comment with our marker (paginate all comments).
+existing_id="$(
+  gh api --paginate \
+    "repos/${repo}/issues/${PR_NUMBER}/comments" \
+    --jq ".[] | select(.body | contains(\"${marker}\")) | .id" \
+    | head -n 1
+)"
+
+if [ -n "$existing_id" ]; then
+  echo "Updating existing sticky comment ${existing_id} (tag: ${STICKY_TAG})"
+  gh api --method PATCH \
+    "repos/${repo}/issues/comments/${existing_id}" \
+    -f body="$full_body" >/dev/null
+else
+  echo "Creating new sticky comment (tag: ${STICKY_TAG})"
+  gh api --method POST \
+    "repos/${repo}/issues/${PR_NUMBER}/comments" \
+    -f body="$full_body" >/dev/null
+fi

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -94,14 +94,12 @@ jobs:
 
       - name: Comment on PR
         if: ${{ steps.wait.outputs.live == 'true' }}
-        uses: thollander/actions-comment-pull-request@v3
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          pr-number: ${{ github.event.pull_request.number }}
-          file-path: ./lhci-comment.md
-          comment-tag: lighthouse-ci
-          mode: upsert
-          create-if-not-exists: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          STICKY_TAG: lighthouse-ci
+          BODY_FILE: ./lhci-comment.md
+        run: .github/scripts/sticky-comment.sh
 
       - name: Note skipped audit
         if: ${{ steps.wait.outputs.live != 'true' }}

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -105,10 +105,9 @@ jobs:
 
       - name: Comment on PR
         if: ${{ github.event_name == 'pull_request' && hashFiles('lychee-report.md') != '' }}
-        uses: thollander/actions-comment-pull-request@v3
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          file-path: ./lychee-report.md
-          comment-tag: lychee-link-check
-          mode: upsert
-          create-if-not-exists: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          STICKY_TAG: lychee-link-check
+          BODY_FILE: ./lychee-report.md
+        run: .github/scripts/sticky-comment.sh

--- a/.github/workflows/pages-branch-previews.yml
+++ b/.github/workflows/pages-branch-previews.yml
@@ -153,6 +153,10 @@ jobs:
       group: gh-pages-deploy
       cancel-in-progress: false
     steps:
+      # Checkout source so .github/scripts/sticky-comment.sh is available for
+      # the "Comment preview URL" step. peaceiris clones gh-pages into its own
+      # temp dir, so this source checkout does not interfere with publishing.
+      - uses: actions/checkout@v7
       - uses: actions/download-artifact@v8
         with:
           name: site

--- a/.github/workflows/pages-branch-previews.yml
+++ b/.github/workflows/pages-branch-previews.yml
@@ -168,12 +168,12 @@ jobs:
           exclude_assets: 'sa.json'
       - name: Comment preview URL
         if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
-        uses: thollander/actions-comment-pull-request@v3
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          message: "🚀 Preview: https://cavandonohoe.github.io/pr-${{ github.event.pull_request.number }}/"
-          mode: upsert
-          create-if-not-exists: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          STICKY_TAG: pr-preview
+          BODY: "🚀 Preview: https://cavandonohoe.github.io/pr-${{ github.event.pull_request.number }}/"
+        run: .github/scripts/sticky-comment.sh
 
   # CLEANUP: delete subfolder when PR closes
   cleanup_preview:

--- a/.github/workflows/repo-size.yml
+++ b/.github/workflows/repo-size.yml
@@ -88,13 +88,12 @@ jobs:
 
       - name: Comment on PR
         if: ${{ github.event_name == 'pull_request' }}
-        uses: thollander/actions-comment-pull-request@v3
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          file-path: ./size-report.md
-          comment-tag: repo-size
-          mode: upsert
-          create-if-not-exists: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          STICKY_TAG: repo-size
+          BODY_FILE: ./size-report.md
+        run: .github/scripts/sticky-comment.sh
 
       - name: Find existing open repo-size issue
         id: find_issue


### PR DESCRIPTION
## Summary

Every PR run was logging:

> Warning: Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: `thollander/actions-comment-pull-request@v3`.

That action's latest release (`v3.0.1`, Nov 2024) still declares `using: 'node20'` and hasn't been updated, so there's no newer tag to bump to. GitHub is force-running it on Node 24 for now and will eventually remove Node 20 from runners entirely.

This removes the dependency instead of waiting on the maintainer:

- Adds `.github/scripts/sticky-comment.sh`, a small shared script that posts or updates a single "sticky" PR comment via the `gh` CLI, keyed by a hidden HTML marker (`<!-- sticky-comment: TAG -->`). This reproduces the action's upsert-by-tag behavior.
- Rewires all four usages to call the script:
  - `repo-size.yml` (tag `repo-size`, file body)
  - `lighthouse.yml` (tag `lighthouse-ci`, file body)
  - `link-check.yml` (tag `lychee-link-check`, file body)
  - `pages-branch-previews.yml` (tag `pr-preview`, inline message body) — this one previously had no explicit `comment-tag`; it now uses `pr-preview` so the sticky-update behavior is preserved.

### Why native `gh` instead of another action
No Node dependency at all, so zero deprecation warning, and one fewer third-party action in the supply chain. All four workflows already declare `pull-requests: write`.

### Verification
- `bash -n` and `shellcheck` both pass on the script.
- All four workflow YAMLs validated.
- No remaining references to the deprecated action (only a comment in the script noting what it replaces).