### PR TITLE
Add X-Men '97 ratings plot and median summary rating

### DIFF
--- a/data/x_men_97_ep_ratings.csv
+++ b/data/x_men_97_ep_ratings.csv
@@ -1,0 +1,18 @@
+season,episode,title,rating,votes
+1,1,"To Me, My X-Men",8.2,7723
+1,2,"Mutant Liberation Begins",9.0,7779
+1,3,"Fire Made Flesh",8.5,6932
+1,4,"Motendo/Lifedeath - Part 1",6.9,6711
+1,5,"Remember It",9.7,12304
+1,6,"Lifedeath - Part 2",7.7,5880
+1,7,"Bright Eyes",8.5,5920
+1,8,"Tolerance Is Extinction - Part 1",9.2,6557
+1,9,"Tolerance Is Extinction - Part 2",9.3,6356
+1,10,"Tolerance Is Extinction - Part 3",9.3,6109
+2,1,"Days of Past Future",8.3,3013
+2,2,"A Force to Be Reckoned With",8.3,2847
+2,3,"Rise of Apocalypse: Part 1",8.5,2762
+2,4,"Rise of Apocalypse Part II",9.5,3464
+2,5,"Weapon X, Lies, and DVDs",7.9,2332
+2,6,"Danger.exe",8.1,1870
+2,7,"Strange Land, Savage Heart",8.1,1318

--- a/imdb_rating_plot.Rmd
+++ b/imdb_rating_plot.Rmd
@@ -188,15 +188,15 @@ shows <- tibble::tribble(
   "Suits", "suits", NA, NA, NA, NA,
   "Ted Lasso", "ted_lasso", NA, NA, NA, NA,
   "The Boys", "the_boys", NA, NA, NA, NA,
-  "The Crown", "crown", NA, NA, NA, NA,
+  # "The Crown", "crown", NA, NA, NA, NA,
   "The Office (US)", "the_office", NA, NA, NA, NA,
   "The Simpsons", "simpsons", 15, 6, 16, 6,
   "The Wire", "the_wire", NA, NA, NA, NA,
   "Vampire Diaries", "vampire_diaries", NA, NA, NA, NA,
   "Velma", "velma", NA, NA, NA, NA,
   "Westworld", "westworld", NA, NA, NA, NA,
-  "X-Men '97", "x_men_97", NA, NA, NA, NA,
-  "ZeroZeroZero", "zerozerozero", NA, NA, NA, NA
+  "X-Men '97", "x_men_97", NA, NA, NA, NA
+  # "ZeroZeroZero", "zerozerozero", NA, NA, NA, NA
 ) %>%
   dplyr::arrange(tolower(title))
 

--- a/imdb_rating_plot.Rmd
+++ b/imdb_rating_plot.Rmd
@@ -195,6 +195,7 @@ shows <- tibble::tribble(
   "Vampire Diaries", "vampire_diaries", NA, NA, NA, NA,
   "Velma", "velma", NA, NA, NA, NA,
   "Westworld", "westworld", NA, NA, NA, NA,
+  "X-Men '97", "x_men_97", NA, NA, NA, NA,
   "ZeroZeroZero", "zerozerozero", NA, NA, NA, NA
 ) %>%
   dplyr::arrange(tolower(title))
@@ -344,4 +345,3 @@ for (i in seq_len(nrow(shows))) {
   });
 })();
 ```
-

--- a/imdb_rating_plot.Rmd
+++ b/imdb_rating_plot.Rmd
@@ -221,6 +221,7 @@ summary_tbl <- shows %>%
     Seasons = purrr::map_int(data, ~ dplyr::n_distinct(.x$season)),
     Episodes = purrr::map_int(data, nrow),
     `Avg rating` = purrr::map_dbl(data, ~ round(mean(.x$rating, na.rm = TRUE), 2)),
+    `Median rating` = purrr::map_dbl(data, ~ round(stats::median(.x$rating, na.rm = TRUE), 2)),
     `Best ep` = purrr::map_chr(data, function(d) {
       top <- d %>% dplyr::slice_max(rating, n = 1, with_ties = FALSE)
       sprintf("%.1f — %s (S%dE%d)", top$rating, top$title, top$season, top$episode)
@@ -231,7 +232,7 @@ summary_tbl <- shows %>%
     }),
     Show = sprintf("<a href='#%s'>%s</a>", anchor_id(title), title)
   ) %>%
-  dplyr::select(Show, Seasons, Episodes, `Avg rating`, `Best ep`, `Worst ep`)
+  dplyr::select(Show, Seasons, Episodes, `Avg rating`, `Median rating`, `Best ep`, `Worst ep`)
 
 DT::datatable(
   summary_tbl,

--- a/web_scraping/imdb_season_episode_ratings_plot.R
+++ b/web_scraping/imdb_season_episode_ratings_plot.R
@@ -346,6 +346,7 @@ shows <- tibble::tribble(
   "andor",              "tt9253284",   "andor",
   "modern love",        "tt8543390",   "modern_love",
   "my hero academia",   "tt5626028",   "my_hero_academia",
+  "x-men 97",           "tt16026746",  "x_men_97",
   "the boys",           "tt1190634",   "the_boys",
   "schitt's creek",     "tt3526078",   "schitts_creek",
   "batman caped crusader", "tt14681596", "batman_caped_crusader",


### PR DESCRIPTION
## Summary

- Add X-Men '97 episode ratings data to the IMDb rating plot page.
- Keep Crown and ZeroZeroZero hidden from the rendered show manifest.
- Add a Median rating column to the IMDb rating plot summary table next to Avg rating.

## Validation

- `Rscript scripts/run_tests.R` (exits successfully; testthat is not installed, so the runner skips)
- `Rscript -e 'rmarkdown::render_site(input = "imdb_rating_plot.Rmd", encoding = "UTF-8")'`
- Pre-push hook: `lintr` and DESCRIPTION validation passed; testthat skipped because no scripts/tests changed.

Ready for review.