### PR TITLE
Add median rating to IMDb summary table

### DIFF
--- a/imdb_rating_plot.Rmd
+++ b/imdb_rating_plot.Rmd
@@ -221,6 +221,7 @@ summary_tbl <- shows %>%
     Seasons = purrr::map_int(data, ~ dplyr::n_distinct(.x$season)),
     Episodes = purrr::map_int(data, nrow),
     `Avg rating` = purrr::map_dbl(data, ~ round(mean(.x$rating, na.rm = TRUE), 2)),
+    `Median rating` = purrr::map_dbl(data, ~ round(stats::median(.x$rating, na.rm = TRUE), 2)),
     `Best ep` = purrr::map_chr(data, function(d) {
       top <- d %>% dplyr::slice_max(rating, n = 1, with_ties = FALSE)
       sprintf("%.1f — %s (S%dE%d)", top$rating, top$title, top$season, top$episode)
@@ -231,7 +232,7 @@ summary_tbl <- shows %>%
     }),
     Show = sprintf("<a href='#%s'>%s</a>", anchor_id(title), title)
   ) %>%
-  dplyr::select(Show, Seasons, Episodes, `Avg rating`, `Best ep`, `Worst ep`)
+  dplyr::select(Show, Seasons, Episodes, `Avg rating`, `Median rating`, `Best ep`, `Worst ep`)
 
 DT::datatable(
   summary_tbl,


### PR DESCRIPTION
## Summary

- Add a Median rating column to the DT summary table at the top of the IMDb rating plot page.
- Keep the change scoped to the summary table only.

## Validation

- `Rscript -e 'rmarkdown::render_site(input = "imdb_rating_plot.Rmd", encoding = "UTF-8")'`
- Pre-push hook passed: `lintr` and DESCRIPTION validation; `testthat` skipped because no scripts/tests changed.

Ready for review.