### PR TITLE
Add Sherlock to IMDb ratings plot

### DIFF
--- a/data/sherlock_ep_ratings.csv
+++ b/data/sherlock_ep_ratings.csv
@@ -1,0 +1,16 @@
+season,episode,title,rating,votes
+1,0,Unaired Pilot,8.7,13572
+1,1,A Study in Pink,8.9,36816
+1,2,The Blind Banker,7.9,31820
+1,3,The Great Game,9,32323
+2,1,A Scandal in Belgravia,9.4,46666
+2,2,The Hounds of Baskerville,8.3,30284
+2,3,The Reichenbach Fall,9.6,44029
+3,0,Many Happy Returns,8.4,13536
+3,1,The Empty Hearse,8.8,33984
+3,2,The Sign of Three,8.9,31151
+3,3,His Last Vow,9.2,33973
+4,0,The Abominable Bride,8,37835
+4,1,The Six Thatchers,7.6,27868
+4,2,The Lying Detective,9.1,31021
+4,3,The Final Problem,8.2,31546

--- a/imdb_rating_plot.Rmd
+++ b/imdb_rating_plot.Rmd
@@ -190,6 +190,7 @@ shows <- tibble::tribble(
   "Schitt's Creek", "schitts_creek", NA, NA, NA, NA,
   "Scrubs", "scrubs", NA, NA, NA, NA,
   "Seinfeld", "seinfeld", NA, NA, NA, NA,
+  "Sherlock", "sherlock", NA, NA, NA, NA,
   "Six Feet Under", "six_feet_under", NA, NA, NA, NA,
   "South Park", "south_park", 15, 6, 16, 6,
   "Sparticus", "sparticus", NA, NA, NA, NA,

--- a/web_scraping/imdb_season_episode_ratings_plot.R
+++ b/web_scraping/imdb_season_episode_ratings_plot.R
@@ -355,6 +355,7 @@ shows <- tibble::tribble(
   "rick and morty",     "tt2861424",   "rick_and_morty",
   "gravity falls",      "tt1865718",   "gravity_falls",
   "seinfeld",           "tt0098904",   "seinfeld",
+  "sherlock",           "tt1475582",   "sherlock",
   "daredevil",          "tt3322312",   "daredevil",
   "the mandalorian",    "tt8111088",   "the_mandalorian",
   "archer",             "tt1486217",   "archer",


### PR DESCRIPTION
## Summary
- Add the BBC series *Sherlock* (`tt1475582`) to the IMDb season/episode ratings heatmap.
- Add a manifest row in `imdb_rating_plot.Rmd` (alphabetically, after Seinfeld).
- Add the show to the scraper config in `web_scraping/imdb_season_episode_ratings_plot.R`.
- Add the fetched episode ratings CSV at `data/sherlock_ep_ratings.csv`.

## Test plan
- [x] Fetched episode data via the scraper's `update_show()` (4 series, incl. specials).
- [x] Verified the CSV loads and the summary-table logic (best/worst episode) works.