### PR TITLE
Make Batman heatmap taller

### DIFF
--- a/data/the_owl_house_ep_ratings.csv
+++ b/data/the_owl_house_ep_ratings.csv
@@ -1,0 +1,44 @@
+season,episode,title,rating,votes
+1,1,A Lying Witch and a Warden,7.7,1994
+1,2,Witches Before Wizards,7.3,1768
+1,3,I Was a Teenage Abomination,7.8,1722
+1,4,The Intruder,8.1,1678
+1,5,Covention,8.5,1867
+1,6,Hooty's Moving Hassle,7.5,1577
+1,7,Lost in Language,8.5,1825
+1,8,Once Upon a Swap,7,1588
+1,9,"Something Ventured, Someone Framed",7.6,1522
+1,10,Escape of the Palisman,7.5,1505
+1,11,Sense and Insensitivity,7.3,1470
+1,12,Adventures in the Elements,8.5,1554
+1,13,The First Day,8.4,1509
+1,14,Really Small Problems,6.9,1489
+1,15,Understanding Willow,9,1829
+1,16,Enchanting Grom Fright,9.3,2159
+1,17,Wing It Like Witches,8.4,1570
+1,18,Agony of a Witch,9.5,2018
+1,19,"Young Blood, Old Souls",9.1,1720
+2,1,Separate Tides,8.1,1578
+2,2,Escaping Expulsion,8.6,1703
+2,3,Echoes of the Past,9,1721
+2,4,Keeping Up A-Fear-Ances,8.1,1455
+2,5,Through the Looking Glass Ruins,8.9,1789
+2,6,Hunting Palismen,9,1574
+2,7,Eda's Requiem,9,1795
+2,8,"Knock, Knock, Knockin' on Hooty's Door",9.6,2614
+2,9,Eclipse Lake,9.1,1702
+2,10,Yesterday's Lie,9.3,1602
+2,11,Follies at the Coven Day Parade,8.3,1286
+2,12,Elsewhere and Elsewhen,8.8,1281
+2,13,Any Sport in a Storm,8.4,1296
+2,14,Reaching Out,9.1,1404
+2,15,"Them's the Breaks, Kid",8.4,1289
+2,16,Hollow Mind,9.6,1920
+2,17,Edge of the World,8.7,1283
+2,18,Labyrinth Runners,8.9,1313
+2,19,"O Titan, Where Art Thou",9.1,1270
+2,20,Clouds on the Horizon,9.3,1409
+2,21,King's Tide,9.7,2127
+3,1,Thanks to Them,9.3,2626
+3,2,For the Future,8.8,1586
+3,3,Watching and Dreaming,9.5,2280

--- a/data/the_punisher_ep_ratings.csv
+++ b/data/the_punisher_ep_ratings.csv
@@ -1,0 +1,27 @@
+season,episode,title,rating,votes
+1,1,3 AM,8.5,12365
+1,2,Two Dead Men,8.1,10545
+1,3,Kandahar,8.3,10156
+1,4,Resupply,8.2,9579
+1,5,Gunner,8.6,9546
+1,6,The Judas Goat,8.1,9133
+1,7,Crosshairs,8.6,9164
+1,8,Cold Steel,8.7,9287
+1,9,Front Toward Enemy,8.9,9606
+1,10,Virtue of the Vicious,9.1,10840
+1,11,Danger Close,9.2,11333
+1,12,Home,9.5,14558
+1,13,Memento Mori,9.2,11494
+2,1,Roadhouse Blues,8.8,8962
+2,2,Fight or Flight,8,7071
+2,3,Trouble the Water,8.8,7490
+2,4,Scar Tissue,7.6,6660
+2,5,One-Eyed Jacks,8.1,6456
+2,6,Nakazat,7.8,6295
+2,7,One Bad Day,8.2,6244
+2,8,My Brother's Keeper,8,6193
+2,9,Flustercluck,8,6080
+2,10,The Dark Hearts of Men,8.6,6592
+2,11,The Abyss,8.3,6117
+2,12,Collision Course,8.7,6459
+2,13,The Whirlwind,9,7673

--- a/imdb_rating_plot.Rmd
+++ b/imdb_rating_plot.Rmd
@@ -196,6 +196,7 @@ shows <- tibble::tribble(
   "Parks and Recreation", "parks_and_rec", NA, NA, NA, NA,
   "Person of Interest", "person_of_interest", NA, NA, NA, NA,
   "Pretty Little Liars", "pretty_little_liars", NA, NA, NA, NA,
+  "The Punisher", "the_punisher", NA, NA, NA, NA,
   "Rick and Morty", "rick_and_morty", NA, NA, NA, NA,
   "Schitt's Creek", "schitts_creek", NA, NA, NA, NA,
   "Scrubs", "scrubs", NA, NA, NA, NA,

--- a/imdb_rating_plot.Rmd
+++ b/imdb_rating_plot.Rmd
@@ -156,7 +156,7 @@ shows <- tibble::tribble(
   "Always Sunny in Philadelphia", "always_sunny", NA, NA, NA, NA,
   "Andor", "andor", NA, NA, NA, NA,
   "Archer", "archer", NA, NA, NA, NA,
-  "Attack on Titan", "attack_on_titan", NA, 7, NA, NA,
+  "Attack on Titan", "attack_on_titan", NA, 9, NA, NA,
   "Avatar: The Last Airbender", "avatar", NA, NA, NA, NA,
   "Barry", "barry", NA, NA, NA, NA,
   "Batman: Caped Crusader", "batman_caped_crusader", NA, NA, NA, NA,

--- a/imdb_rating_plot.Rmd
+++ b/imdb_rating_plot.Rmd
@@ -125,10 +125,20 @@ create_episode_plot <- function(episode_data, title, export_png = TRUE,
   episode_plot
 }
 
-interactive_plotly <- function(gg_object) {
+interactive_plotly <- function(gg_object, fig_width = NA, fig_height = NA) {
+  px_per_in <- 96
+  plot_width <- if (is.na(fig_width)) NULL else fig_width * px_per_in
+  plot_height <- if (is.na(fig_height)) NULL else fig_height * px_per_in
+
   gg_object %>%
-    plotly::ggplotly(tooltip = "text") %>%
-    plotly::layout(xaxis = list(side = "top"))
+    plotly::ggplotly(
+      tooltip = "text",
+      width = plot_width,
+      height = plot_height
+    ) %>%
+    plotly::layout(
+      xaxis = list(side = "top")
+    )
 }
 ```
 
@@ -150,7 +160,7 @@ shows <- tibble::tribble(
   "Avatar: The Last Airbender", "avatar", NA, NA, NA, NA,
   "Barry", "barry", NA, NA, NA, NA,
   "Batman: Caped Crusader", "batman_caped_crusader", NA, NA, NA, NA,
-  "Batman: The Animated Series", "batman_animated_series", 7, 14, NA, NA,
+  "Batman: The Animated Series", "batman_animated_series", 7, 16, NA, NA,
   "Better Call Saul", "better_call_saul", NA, NA, NA, NA,
   "Blue Eye Samurai", "blue_eye_samurai", NA, NA, NA, NA,
   "Bluey", "bluey", 4, 9, NA, NA,
@@ -297,7 +307,11 @@ render_one_show <- function(row) {
     data, row$title,
     png_width = png_w, png_height = png_h
   )
-  widget <- interactive_plotly(gg)
+  widget <- interactive_plotly(
+    gg,
+    fig_width = row$fig_width,
+    fig_height = row$fig_height
+  )
   rendered <- htmltools::renderTags(widget)
 
   # Keep the heatmap legible on narrow screens: give the plot a per-season

--- a/imdb_rating_plot.Rmd
+++ b/imdb_rating_plot.Rmd
@@ -212,6 +212,7 @@ shows <- tibble::tribble(
   #   "The Crown", "crown", NA, NA, NA, NA,
   "The Mandalorian", "the_mandalorian", NA, NA, NA, NA,
   "The Office (US)", "the_office", NA, NA, NA, NA,
+  "The Owl House", "the_owl_house", NA, NA, NA, NA,
   "The Simpsons", "simpsons", 15, 6, 16, 6,
   "The Wire", "the_wire", NA, NA, NA, NA,
   "Vampire Diaries", "vampire_diaries", NA, NA, NA, NA,

--- a/web_scraping/imdb_season_episode_ratings_plot.R
+++ b/web_scraping/imdb_season_episode_ratings_plot.R
@@ -359,6 +359,7 @@ shows <- tibble::tribble(
   "sherlock",           "tt1475582",   "sherlock",
   "daredevil",          "tt3322312",   "daredevil",
   "the mandalorian",    "tt8111088",   "the_mandalorian",
+  "the owl house",      "tt8050756",   "the_owl_house",
   "archer",             "tt1486217",   "archer",
   "heated rivalry",     "tt35495073",  "heated_rivalry",
   "scrubs",             "tt0285403",   "scrubs",

--- a/web_scraping/imdb_season_episode_ratings_plot.R
+++ b/web_scraping/imdb_season_episode_ratings_plot.R
@@ -348,6 +348,7 @@ shows <- tibble::tribble(
   "my hero academia",   "tt5626028",   "my_hero_academia",
   "x-men 97",           "tt16026746",  "x_men_97",
   "the boys",           "tt1190634",   "the_boys",
+  "the punisher",       "tt5675620",   "the_punisher",
   "schitt's creek",     "tt3526078",   "schitts_creek",
   "batman caped crusader", "tt14681596", "batman_caped_crusader",
   "batman the animated series", "tt0103359", "batman_animated_series",


### PR DESCRIPTION
## Summary

Updates the IMDb ratings page so custom per-show figure dimensions are passed into the interactive Plotly widgets, then increases the Batman: The Animated Series heatmap height from 14 to 16 inches and the Attack on Titan heatmap height from 7 to 9 inches. This gives long seasons more vertical room so their episode lists are easier to see when each section is expanded.

Also adds The Punisher and The Owl House to the IMDb ratings mix, including new episode-rating CSV files and scraper manifest entries for future refreshes.

## Validation

- `git diff --check`
- Focused `Rscript` checks for `ggplotly(width, height)` behavior
- `Rscript` check that `data/the_punisher_ep_ratings.csv` has 26 rows, required columns, and 2 seasons of 13 episodes each
- `Rscript` check that `data/the_owl_house_ep_ratings.csv` has 43 rows, required columns, and seasons with 19, 21, and 3 episodes
- Pre-push hook: lintr passed, DESCRIPTION validation passed; typos skipped because `typos` is not installed, testthat skipped because no scripts/tests changed

Full `rmarkdown::render('imdb_rating_plot.Rmd')` is currently blocked by the existing pandoc asset error for `/header/apple-touch-icon.png`.
